### PR TITLE
An alternative way to load peripherals information

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ Once you have the SVD file, specify the location of it in your `launch.json` usi
 }
 ```
 
+### Extending Peripheral Inspector
+
+It is possible to extend the Peripheral Inspector with new file extension providers in your VSCode extension. This method will provide reading new file formats and load the peripherals information into the Peripheral Inspector.
+
+```json
+{
+    ...
+    "definitionPath": "${workspaceFolder}/STM32F103.<customFileExtension>"
+    ...
+}
+```
+
+For more details about the implementation, please check the [Extending Peripheral Inspector](./docs/extending-peripheral-inspector.md) document.
+
 ## Settings
 
 All variable key names used to extract data from debug launch configurations can be modified. This allows variable name clashes to be avoided as well as the need to duplicate configuration entries.

--- a/api.ts
+++ b/api.ts
@@ -1,0 +1,1 @@
+export * from './src/api-types';

--- a/docs/extending-peripheral-inspector.md
+++ b/docs/extending-peripheral-inspector.md
@@ -1,0 +1,74 @@
+# Extending Peripheral Inspector
+
+It is possible to extend the Peripheral Inspector with new file extension providers in your VSCode extension. This method will provide reading new file formats and load the peripherals information into the Peripheral Inspector.
+
+## Building your VSCode Extension to extend Peripheral Inspector
+
+This is a guide about how you can register new peripheral providers to Peripheral Inspector in your VSCode extension. Please refer to [VSCode Extension API](https://code.visualstudio.com/api) for more information about developing VSCode extensions.
+
+### Adding Peripheral Inspector to your VSCode extension
+
+You need to install eclipse-cdt-cloud/vscode-peripheral-inspector to access the types information. You can use `npm` or `yarn` with the following arguments described below:
+
+Using with npm:
+```bash
+npm install github:eclipse-cdt-cloud/vscode-peripheral-inspector
+```
+Using with yarn:
+```bash
+yarn add github:eclipse-cdt-cloud/vscode-peripheral-inspector
+```
+
+### Developing your extension
+
+To provide the peripherals information to Peripheral Inspector on debug session time, you need register your command which is going to construct the peripherals information. The command will receive `DebugSession` object as an input parameter and expects to return array of type `PeripheralOptions[]`.
+
+You can find the example command implementation below:
+
+```js
+import { ExtensionContext } from 'vscode';
+import type * as api from "peripheral-inspector/api";
+
+
+class MyExtensionProvider implements api.IPeripheralsProvider {
+    public async getPeripherals (data: string, options: api.IGetPeripheralsArguments): Promise<api.PeripheralOptions[]> {
+        // Load your peripherals data
+        const peripherals: api.PeripheralOptions[] = ...
+        return peripherals;
+    }
+}
+
+export async function activate(context: ExtensionContext) {
+    ...
+    // Get the eclipse-cdt.peripheral-inspector extension
+    const peripheralInspectorExtention = extensions.getExtension<api.IPeripheralInspectorAPI>('eclipse-cdt.peripheral-inspector');
+
+    // Check if the eclipse-cdt.peripheral-inspector extension is installed
+    if (peripheralInspectorExtention) {
+        const peripheralInspectorAPI = await peripheralInspectorExtention.activate();
+
+        // Invoke registerPeripheralsProvider method in eclipse-cdt.peripheral-inspector extension api
+        // Register 'MyExtensionProvider' for files *.myext
+        peripheralInspectorAPI.registerPeripheralsProvider('myext', new MyExtensionProvider());
+    }
+    ...
+}
+```
+
+For further information about the api definitions, review the [Peripheral Inspector API Definitions](../src/api-types.ts).
+
+### Modifying your package.json
+
+In `package.json` of your VSCode extension project, you need to define the dependency between Peripheral Inspector and your extension. 
+
+You need to define Peripheral Inspector in the `extensionDependencies` as shown below:
+
+```json
+{
+  ...
+  "extensionDependencies": [
+    "eclipse-cdt.peripheral-inspector"
+  ],
+  ...
+}
+```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/desktop/extension.js",
   "browser": "dist/browser/extension.js",
+  "types": "dist/desktop/extension.d.ts",
   "repository": "https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector",
   "qna": "https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues",
   "icon": "media/cdtcloud.png",

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -1,0 +1,83 @@
+// Peripheral Inspector API
+export interface IPeripheralInspectorAPI {
+	registerSVDFile: (expression: RegExp | string, path: string) => void;
+	getSVDFile: (device: string) => string | undefined;
+	getSVDFileFromCortexDebug: (device: string) => Promise<string | undefined>;
+	registerPeripheralsProvider: (fileExtension: string, provider: IPeripheralsProvider) => void;
+}
+
+export interface IPeripheralsProvider {
+	getPeripherals: (data: string, options: IGetPeripheralsArguments) => Promise<PeripheralOptions[]>;
+}
+
+export interface IGetPeripheralsArguments {
+	gapThreshold: number;
+}
+
+export interface PeripheralOptions {
+	name: string;
+	baseAddress: number;
+	totalLength: number;
+	description: string;
+	groupName?: string;
+	accessType?: AccessType;
+	size?: number;
+	resetValue?: number;
+	registers?: PeripheralRegisterOptions[];
+	clusters?: ClusterOptions[];
+}
+
+export interface PeripheralRegisterOptions {
+	name: string;
+	description?: string;
+	addressOffset: number;
+	accessType?: AccessType;
+	size?: number;
+	resetValue?: number;
+	fields?: FieldOptions[];
+}
+
+export interface ClusterOptions {
+	name: string;
+	description?: string;
+	addressOffset: number;
+	accessType?: AccessType;
+	size?: number;
+	resetValue?: number;
+	registers?: PeripheralRegisterOptions[];
+	clusters?: ClusterOptions[];
+}
+
+export interface FieldOptions {
+	name: string;
+	description: string;
+	offset: number;
+	width: number;
+	enumeration?: EnumerationMap;
+	derivedFrom?: string;           // Set this if unresolved
+	accessType?: AccessType;
+}
+
+export interface IGetPeripheralsArguments {
+	gapThreshold: number;
+}
+
+export interface IPeripheralsProvider {
+	getPeripherals: (data: string, options: IGetPeripheralsArguments) => Promise<PeripheralOptions[]>;
+}
+
+export declare enum AccessType {
+    ReadOnly = 1,
+    ReadWrite = 2,
+    WriteOnly = 3
+}
+
+export interface EnumerationMap {
+	[value: number]: IEnumeratedValue;
+}
+
+export interface IEnumeratedValue {
+	name: string;
+	description: string;
+	value: number;
+}

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -1,83 +1,83 @@
 // Peripheral Inspector API
 export interface IPeripheralInspectorAPI {
-	registerSVDFile: (expression: RegExp | string, path: string) => void;
-	getSVDFile: (device: string) => string | undefined;
-	getSVDFileFromCortexDebug: (device: string) => Promise<string | undefined>;
-	registerPeripheralsProvider: (fileExtension: string, provider: IPeripheralsProvider) => void;
+    registerSVDFile: (expression: RegExp | string, path: string) => void;
+    getSVDFile: (device: string) => string | undefined;
+    getSVDFileFromCortexDebug: (device: string) => Promise<string | undefined>;
+    registerPeripheralsProvider: (fileExtension: string, provider: IPeripheralsProvider) => void;
 }
 
 export interface IPeripheralsProvider {
-	getPeripherals: (data: string, options: IGetPeripheralsArguments) => Promise<PeripheralOptions[]>;
+    getPeripherals: (data: string, options: IGetPeripheralsArguments) => Promise<PeripheralOptions[]>;
 }
 
 export interface IGetPeripheralsArguments {
-	gapThreshold: number;
+    gapThreshold: number;
 }
 
 export interface PeripheralOptions {
-	name: string;
-	baseAddress: number;
-	totalLength: number;
-	description: string;
-	groupName?: string;
-	accessType?: AccessType;
-	size?: number;
-	resetValue?: number;
-	registers?: PeripheralRegisterOptions[];
-	clusters?: ClusterOptions[];
+    name: string;
+    baseAddress: number;
+    totalLength: number;
+    description: string;
+    groupName?: string;
+    accessType?: AccessType;
+    size?: number;
+    resetValue?: number;
+    registers?: PeripheralRegisterOptions[];
+    clusters?: ClusterOptions[];
 }
 
 export interface PeripheralRegisterOptions {
-	name: string;
-	description?: string;
-	addressOffset: number;
-	accessType?: AccessType;
-	size?: number;
-	resetValue?: number;
-	fields?: FieldOptions[];
+    name: string;
+    description?: string;
+    addressOffset: number;
+    accessType?: AccessType;
+    size?: number;
+    resetValue?: number;
+    fields?: FieldOptions[];
 }
 
 export interface ClusterOptions {
-	name: string;
-	description?: string;
-	addressOffset: number;
-	accessType?: AccessType;
-	size?: number;
-	resetValue?: number;
-	registers?: PeripheralRegisterOptions[];
-	clusters?: ClusterOptions[];
+    name: string;
+    description?: string;
+    addressOffset: number;
+    accessType?: AccessType;
+    size?: number;
+    resetValue?: number;
+    registers?: PeripheralRegisterOptions[];
+    clusters?: ClusterOptions[];
 }
 
 export interface FieldOptions {
-	name: string;
-	description: string;
-	offset: number;
-	width: number;
-	enumeration?: EnumerationMap;
-	derivedFrom?: string;           // Set this if unresolved
-	accessType?: AccessType;
+    name: string;
+    description: string;
+    offset: number;
+    width: number;
+    enumeration?: EnumerationMap;
+    derivedFrom?: string;           // Set this if unresolved
+    accessType?: AccessType;
 }
 
 export interface IGetPeripheralsArguments {
-	gapThreshold: number;
+    gapThreshold: number;
 }
 
 export interface IPeripheralsProvider {
-	getPeripherals: (data: string, options: IGetPeripheralsArguments) => Promise<PeripheralOptions[]>;
+    getPeripherals: (data: string, options: IGetPeripheralsArguments) => Promise<PeripheralOptions[]>;
 }
 
-export declare enum AccessType {
+export enum AccessType {
     ReadOnly = 1,
     ReadWrite = 2,
     WriteOnly = 3
 }
 
 export interface EnumerationMap {
-	[value: number]: IEnumeratedValue;
+    [value: number]: IEnumeratedValue;
 }
 
 export interface IEnumeratedValue {
-	name: string;
-	description: string;
-	value: number;
+    name: string;
+    description: string;
+    value: number;
 }

--- a/src/browser/extension.ts
+++ b/src/browser/extension.ts
@@ -9,21 +9,23 @@ import * as vscode from 'vscode';
 import { PeripheralTreeProvider } from '../views/peripheral';
 import { Commands } from '../commands';
 import { DebugTracker } from '../debug-tracker';
-import { SvdRegistry } from '../svd-registry';
+import { PeripheralInspectorAPI } from '../peripheral-inspector-api';
 import { SvdResolver } from '../svd-resolver';
+import { IPeripheralInspectorAPI } from '../api-types';
+export * as api from '../api-types';
 
-export const activate = async (context: vscode.ExtensionContext): Promise<SvdRegistry> => {
+export const activate = async (context: vscode.ExtensionContext): Promise<IPeripheralInspectorAPI> => {
     const tracker = new DebugTracker();
-    const registry = new SvdRegistry();
-    const resolver = new SvdResolver(registry);
-    const peripheralTree = new PeripheralTreeProvider(tracker, resolver, context);
+    const api = new PeripheralInspectorAPI();
+    const resolver = new SvdResolver(api);
+    const peripheralTree = new PeripheralTreeProvider(tracker, resolver, api, context);
     const commands = new Commands(peripheralTree);
 
     await tracker.activate(context);
     await peripheralTree.activate();
     await commands.activate(context);
 
-    return registry;
+    return api;
 };
 
 export const deactivate = async (): Promise<void> => {

--- a/src/desktop/extension.ts
+++ b/src/desktop/extension.ts
@@ -9,21 +9,23 @@ import * as vscode from 'vscode';
 import { PeripheralTreeProvider } from '../views/peripheral';
 import { Commands } from '../commands';
 import { DebugTracker } from '../debug-tracker';
-import { SvdRegistry } from '../svd-registry';
+import { PeripheralInspectorAPI } from '../peripheral-inspector-api';
 import { SvdResolver } from '../svd-resolver';
+import { IPeripheralInspectorAPI } from '../api-types';
+export * as api from '../api-types';
 
-export const activate = async (context: vscode.ExtensionContext): Promise<SvdRegistry> => {
+export const activate = async (context: vscode.ExtensionContext): Promise<IPeripheralInspectorAPI> => {
     const tracker = new DebugTracker();
-    const registry = new SvdRegistry();
-    const resolver = new SvdResolver(registry);
-    const peripheralTree = new PeripheralTreeProvider(tracker, resolver, context);
+    const api = new PeripheralInspectorAPI();
+    const resolver = new SvdResolver(api);
+    const peripheralTree = new PeripheralTreeProvider(tracker, resolver, api, context);
     const commands = new Commands(peripheralTree);
 
     await tracker.activate(context);
     await peripheralTree.activate();
     await commands.activate(context);
 
-    return registry;
+    return api;
 };
 
 export const deactivate = async (): Promise<void> => {

--- a/src/enumerated-value.ts
+++ b/src/enumerated-value.ts
@@ -1,0 +1,3 @@
+export class EnumeratedValue {
+    constructor(public name: string, public description: string, public value: number) {}
+}

--- a/src/memreadutils.ts
+++ b/src/memreadutils.ts
@@ -38,7 +38,7 @@ export class MemUtils {
                         storeTo[dst++] = byte;
                     }
                 }
-            } catch (e: unknown) {
+            } catch (e: any) {
                 const err = e ? e.toString() : 'Unknown error';
                 errors.push(new Error(`readMemory failed @ ${memoryReference} for ${request.count} bytes: ${err}, session=${session.id}`));
             }

--- a/src/svd-parser.ts
+++ b/src/svd-parser.ts
@@ -9,15 +9,13 @@
 
 import { PeripheralRegisterNode } from './views/nodes/peripheralregisternode';
 import { PeripheralClusterNode, PeripheralOrClusterNode } from './views/nodes/peripheralclusternode';
-import { PeripheralFieldNode, EnumerationMap, EnumeratedValue } from './views/nodes/peripheralfieldnode';
+import { PeripheralFieldNode } from './views/nodes/peripheralfieldnode';
 import { PeripheralNode } from './views/nodes/peripheralnode';
 import { parseInteger, parseDimIndex } from './utils';
+import { parseStringPromise } from 'xml2js';
+import { AccessType, EnumerationMap } from './api-types';
+import { EnumeratedValue } from './enumerated-value';
 
-export enum AccessType {
-    ReadOnly = 1,
-    ReadWrite,
-    WriteOnly
-}
 
 const accessTypeFromString = (type: string): AccessType => {
     switch (type) {
@@ -62,7 +60,8 @@ export class SVDParser {
     constructor() {}
 
     public async parseSVD(
-        svdData: SvdData, gapThreshold: number): Promise<PeripheralNode[]> {
+        data: string, gapThreshold: number): Promise<PeripheralNode[]> {
+        const svdData: SvdData = await parseStringPromise(data);
         this.gapThreshold = gapThreshold;
         this.enumTypeValuesMap = {};
         this.peripheralRegisterMap = {};
@@ -479,3 +478,5 @@ export class SVDParser {
         return peripheral;
     }
 }
+
+

--- a/src/svd-resolver.ts
+++ b/src/svd-resolver.ts
@@ -9,13 +9,13 @@ import * as vscode from 'vscode';
 import * as manifest from './manifest';
 import { isAbsolute, join, normalize } from 'path';
 import { parseStringPromise } from 'xml2js';
-import { SvdRegistry } from './svd-registry';
+import { PeripheralInspectorAPI } from './peripheral-inspector-api';
 import { parsePackString, pdscFromPack, fileFromPack, Pack } from './cmsis-pack/pack-utils';
 import { PDSC, Device, DeviceVariant, getDevices, getSvdPath, getProcessors } from './cmsis-pack/pdsc';
 import { readFromUrl } from './utils';
 
 export class SvdResolver {
-    public constructor(protected registry: SvdRegistry) {
+    public constructor(protected api: PeripheralInspectorAPI) {
     }
 
     public async resolve(session: vscode.DebugSession, wsFolderPath?: vscode.Uri): Promise<string | undefined> {
@@ -45,9 +45,9 @@ export class SvdResolver {
                     }
                 }
             } else if (deviceName) {
-                svdPath = this.registry.getSVDFile(deviceName);
+                svdPath = this.api.getSVDFile(deviceName);
                 if (!svdPath) {
-                    svdPath = await this.registry.getSVDFileFromCortexDebug(deviceName);
+                    svdPath = await this.api.getSVDFileFromCortexDebug(deviceName);
                 }
             }
         } catch(e) {

--- a/src/views/nodes/basenode.ts
+++ b/src/views/nodes/basenode.ts
@@ -8,7 +8,7 @@
 import { Command, TreeItem, DebugSession } from 'vscode';
 import { NumberFormat, NodeSetting } from '../../common';
 import { AddrRange } from '../../addrranges';
-import { EnumerationMap } from './peripheralfieldnode';
+import { EnumerationMap } from '../../api-types';
 
 export abstract class BaseNode {
     public expanded: boolean;

--- a/src/views/nodes/peripheralclusternode.ts
+++ b/src/views/nodes/peripheralclusternode.ts
@@ -9,20 +9,11 @@ import * as vscode from 'vscode';
 import { PeripheralBaseNode, ClusterOrRegisterBaseNode } from './basenode';
 import { PeripheralRegisterNode } from './peripheralregisternode';
 import { PeripheralNode } from './peripheralnode';
-import { AccessType } from '../../svd-parser';
 import { NodeSetting, NumberFormat } from '../../common';
 import { AddrRange } from '../../addrranges';
 import { hexFormat } from '../../utils';
-import { EnumerationMap } from './peripheralfieldnode';
+import { AccessType, ClusterOptions, EnumerationMap } from '../../api-types';
 
-export interface ClusterOptions {
-    name: string;
-    description?: string;
-    addressOffset: number;
-    accessType?: AccessType;
-    size?: number;
-    resetValue?: number;
-}
 
 export type PeripheralOrClusterNode = PeripheralNode | PeripheralClusterNode;
 export type PeripheralRegisterOrClusterNode = PeripheralRegisterNode | PeripheralClusterNode;
@@ -46,6 +37,16 @@ export class PeripheralClusterNode extends ClusterOrRegisterBaseNode {
         this.resetValue = options.resetValue || parent.resetValue;
         this.children = [];
         this.parent.addChild(this);
+
+        options.clusters?.forEach((clusterOptions) => {
+            const cluster = new PeripheralClusterNode(this, clusterOptions);
+            this.addChild(cluster);
+        });
+
+        options.registers?.forEach((registerOptions) => {
+            const register = new PeripheralRegisterNode(this, registerOptions);
+            this.addChild(register);
+        });
     }
 
     public getTreeItem(): vscode.TreeItem | Promise<vscode.TreeItem> {

--- a/src/views/nodes/peripheralfieldnode.ts
+++ b/src/views/nodes/peripheralfieldnode.ts
@@ -8,28 +8,10 @@
 import * as vscode from 'vscode';
 import { PeripheralBaseNode } from './basenode';
 import { PeripheralRegisterNode } from './peripheralregisternode';
-import { AccessType } from '../../svd-parser';
 import { AddrRange } from '../../addrranges';
 import { NumberFormat, NodeSetting } from '../../common';
 import { parseInteger, binaryFormat, hexFormat } from '../../utils';
-
-export interface EnumerationMap {
-    [value: number]: EnumeratedValue;
-}
-
-export class EnumeratedValue {
-    constructor(public name: string, public description: string, public value: number) {}
-}
-
-export interface FieldOptions {
-    name: string;
-    description: string;
-    offset: number;
-    width: number;
-    enumeration?: EnumerationMap;
-    derivedFrom?: string;           // Set this if unresolved
-    accessType?: AccessType;
-}
+import { AccessType, EnumerationMap, FieldOptions } from '../../api-types';
 
 export class PeripheralFieldNode extends PeripheralBaseNode {
     public session: vscode.DebugSession | undefined;

--- a/src/views/nodes/peripheralnode.ts
+++ b/src/views/nodes/peripheralnode.ts
@@ -12,20 +12,8 @@ import { PeripheralClusterNode, PeripheralRegisterOrClusterNode } from './periph
 import { AddrRange, AddressRangesUtils } from '../../addrranges';
 import { NumberFormat, NodeSetting } from '../../common';
 import { MemUtils } from '../../memreadutils';
-import { AccessType } from '../../svd-parser';
 import { hexFormat } from '../../utils';
-import { EnumerationMap } from './peripheralfieldnode';
-
-export interface PeripheralOptions {
-    name: string;
-    baseAddress: number;
-    totalLength: number;
-    description: string;
-    groupName?: string;
-    accessType?: AccessType;
-    size?: number;
-    resetValue?: number;
-}
+import { AccessType, EnumerationMap, PeripheralOptions } from '../../api-types';
 
 export class PeripheralNode extends PeripheralBaseNode {
     private children: Array<PeripheralRegisterNode | PeripheralClusterNode>;
@@ -54,6 +42,16 @@ export class PeripheralNode extends PeripheralBaseNode {
         this.size = options.size || 32;
         this.children = [];
         this.addrRanges = [];
+
+        options.clusters?.forEach((clusterOptions) => {
+            const cluster = new PeripheralClusterNode(this, clusterOptions);
+            this.addChild(cluster);
+        });
+
+        options.registers?.forEach((registerOptions) => {
+            const register = new PeripheralRegisterNode(this, registerOptions);
+            this.addChild(register);
+        });
     }
 
     public getPeripheral(): PeripheralBaseNode {

--- a/src/views/nodes/peripheralregisternode.ts
+++ b/src/views/nodes/peripheralregisternode.ts
@@ -9,21 +9,12 @@ import * as vscode from 'vscode';
 import { PeripheralNode } from './peripheralnode';
 import { PeripheralClusterNode } from './peripheralclusternode';
 import { ClusterOrRegisterBaseNode, PeripheralBaseNode } from './basenode';
-import { EnumerationMap, PeripheralFieldNode } from './peripheralfieldnode';
+import { PeripheralFieldNode } from './peripheralfieldnode';
 import { extractBits, createMask, hexFormat, binaryFormat } from '../../utils';
 import { NumberFormat, NodeSetting } from '../../common';
-import { AccessType } from '../../svd-parser';
 import { AddrRange } from '../../addrranges';
 import { MemUtils } from '../../memreadutils';
-
-export interface PeripheralRegisterOptions {
-    name: string;
-    description?: string;
-    addressOffset: number;
-    accessType?: AccessType;
-    size?: number;
-    resetValue?: number;
-}
+import { AccessType, EnumerationMap, PeripheralRegisterOptions } from '../../api-types';
 
 export class PeripheralRegisterNode extends ClusterOrRegisterBaseNode {
     public children: PeripheralFieldNode[];
@@ -59,6 +50,10 @@ export class PeripheralRegisterNode extends ClusterOrRegisterBaseNode {
         this.hexRegex = new RegExp(`^0x[0-9a-f]{1,${this.hexLength}}$`, 'i');
         this.children = [];
         this.parent.addChild(this);
+
+        options.fields?.forEach((fieldOptions) => {
+            this.addChild(new PeripheralFieldNode(this, fieldOptions));
+        });
     }
 
     public reset(): void {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
         "module": "commonjs",
         "strict": true,
         "sourceMap": true,
+        "outDir": "dist",
+        "declaration": true,
         "lib": [
             "dom"
         ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,6 @@
         "module": "commonjs",
         "strict": true,
         "sourceMap": true,
-        "outDir": "dist",
-        "declaration": true,
         "lib": [
             "dom"
         ]


### PR DESCRIPTION
Hi,

This implementation contains a new ability to extend SVD Viewer to support not only SVD file format but also different formats. With this implementation the retrieving logic of the peripherals information separated from `PeripheralTreeProvider` class and extracted to a different class. In addition, a new parameter `getPeripherals` introduced, which enables `svd-viewer` to load the peripherals information from a different VSCode extension during the debug session by invoking the VSCode command defined in the `getPeripherals` launch parameter.

We believe this implementation provide a new ability to `svd-viewer` and we are kindly asking for review for this pull request. We also extend the documentation and provide a basic guideline for users to extend the `svd-viewer` by implementing their own VSCode plugins.

Kind regards.
Asim Gunes