### PR TITLE
Bugfix for duplicate insertation of registers while extending new file providers

### DIFF
--- a/src/views/nodes/peripheralclusternode.ts
+++ b/src/views/nodes/peripheralclusternode.ts
@@ -39,13 +39,13 @@ export class PeripheralClusterNode extends ClusterOrRegisterBaseNode {
         this.parent.addChild(this);
 
         options.clusters?.forEach((clusterOptions) => {
-            const cluster = new PeripheralClusterNode(this, clusterOptions);
-            this.addChild(cluster);
+            // PeripheralClusterNode constructor already adding the reference as child to parent object (PeripheralClusterNode object)
+            new PeripheralClusterNode(this, clusterOptions);
         });
 
         options.registers?.forEach((registerOptions) => {
-            const register = new PeripheralRegisterNode(this, registerOptions);
-            this.addChild(register);
+            // PeripheralRegisterNode constructor already adding the reference as child to parent object (PeripheralClusterNode object)
+            new PeripheralRegisterNode(this, registerOptions);
         });
     }
 

--- a/src/views/nodes/peripheralnode.ts
+++ b/src/views/nodes/peripheralnode.ts
@@ -44,13 +44,13 @@ export class PeripheralNode extends PeripheralBaseNode {
         this.addrRanges = [];
 
         options.clusters?.forEach((clusterOptions) => {
-            const cluster = new PeripheralClusterNode(this, clusterOptions);
-            this.addChild(cluster);
+            // PeripheralClusterNode constructor already adding the reference as child to parent object (PeripheralNode object)
+            new PeripheralClusterNode(this, clusterOptions);
         });
 
         options.registers?.forEach((registerOptions) => {
-            const register = new PeripheralRegisterNode(this, registerOptions);
-            this.addChild(register);
+            // PeripheralRegisterNode constructor already adding the reference as child to parent object (PeripheralNode object)
+            new PeripheralRegisterNode(this, registerOptions);
         });
     }
 

--- a/src/views/nodes/peripheralregisternode.ts
+++ b/src/views/nodes/peripheralregisternode.ts
@@ -52,7 +52,8 @@ export class PeripheralRegisterNode extends ClusterOrRegisterBaseNode {
         this.parent.addChild(this);
 
         options.fields?.forEach((fieldOptions) => {
-            this.addChild(new PeripheralFieldNode(this, fieldOptions));
+            // PeripheralFieldNode constructor already adding the reference as child to parent object (PeripheralRegisterNode object)
+            new PeripheralFieldNode(this, fieldOptions);
         });
     }
 


### PR DESCRIPTION
Hi @thegecko,

Unfortunately, due to the latest update, I recently realised a problem. The problem is adding the child nodes twice while constructing the peripheral information tree as you can see the sample information in the screenshot below.

![image](https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/assets/39078160/8d4c5ba0-76d6-49f4-ba3e-bc54fc3adf3d)
 
The root cause of the problem coming from the foreach logic while creating and appending the child objects. The child object's constuctor is already appending itself to parent object with the following code line `this.parent.addChild(this);`. 

I kept the `this.parent.addChild(this);` line since it is coming from earlier implementation and modify the latest changes to fix the problem.

Could you please review this pull-request related to the problem fix when you are suitable?

Kind regards
Asim