### PR TITLE
Add write permission for release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     needs: build
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We are locking down the GITHUB_TOKEN permissions and need to specify this write permission explicitly.

See: https://github.com/eclipse-cdt-cloud/.eclipsefdn/pull/15