### PR TITLE
Improve ignored peripheral list

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ The following list outlines the setting names and default values:
 Additionally the following settings can be used to customize the Peripheral Inspector:
 
 - `peripheral-inspector.saveLayout`- Save layout of peripheral view between sessions (default: `true`)
-- `peripheral-inspector.ignorePeripherals` - List of variable names to ignore. They will not show up in the tree view. The user can add variables by using the context menu (**Workspace only**) in the tree view, or by setting them manually in the **User** and **Workspace** preferences.
+- `peripheral-inspector.ignorePeripherals` - List of peripheral names to ignore. They will not show up in the tree view and no values are read from the target system. The user can add variables by using the context menu (**Workspace only**) in the tree view, or by setting them manually in the **User** and **Workspace** preferences.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If the pack supports multiple devices and/or processors, you will be prompted to
 }
 ```
 
-__TIP:__ The pack reference and device name can be automatically derived if you use the [Arm Device Manager extension in VS Code](https://marketplace.visualstudio.com/items?itemName=Arm.device-manager) using these commands:
+**TIP:** The pack reference and device name can be automatically derived if you use the [Arm Device Manager extension in VS Code](https://marketplace.visualstudio.com/items?itemName=Arm.device-manager) using these commands:
 
 ```json
 {
@@ -94,3 +94,10 @@ The following list outlines the setting names and default values:
 - `peripheral-inspector.definitionPathConfig` - Debug configuration key to use to get the SVD path (default `definitionPath`)
 - `peripheral-inspector.deviceConfig` - Debug configuration key to use to get the device name (default: `deviceName`)
 - `peripheral-inspector.processorConfig` - Debug configuration key to use to get the processor name (default: `processorName`)
+- `peripheral-inspector.packAssetUrl` - Base URL for CMSIS pack assets (default: `https://pack-content.cmsis.io`)
+- `peripheral-inspector.svdAddrGapThreshold`- If the gap between registers is less than this threshold (multiple of 8), combine into a single read from device. -1 means never combine registers and is very slow (default: `16`)
+
+Additionally the following settings can be used to customize the Peripheral Inspector:
+
+- `peripheral-inspector.saveLayout`- Save layout of peripheral view between sessions (default: `true`)
+- `peripheral-inspector.ignorePeripherals` - List of variable names to ignore. They will not show up in the tree view. The user can add variables by using the context menu (**Workspace only**) in the tree view, or by setting them manually in the **User** and **Workspace** preferences.

--- a/package.json
+++ b/package.json
@@ -147,6 +147,16 @@
         "command": "peripheral-inspector.svd.exportAll",
         "title": "Export All",
         "icon": "$(desktop-download)"
+      },
+      {
+        "command": "peripheral-inspector.svd.ignorePeripheral",
+        "title": "Ignore Peripheral",
+        "icon": "$(circle-slash)"
+      },
+      {
+        "command": "peripheral-inspector.svd.clearIgnoredPeripherals",
+        "title": "Clear Ignored Peripherals",
+        "icon": "$(clear-all)"
       }
     ],
     "menus": {
@@ -189,6 +199,14 @@
         },
         {
           "command": "peripheral-inspector.svd.refreshAll",
+          "when": "false"
+        },
+        {
+          "command": "peripheral-inspector.svd.ignorePeripheral",
+          "when": "false"
+        },
+        {
+          "command": "peripheral-inspector.svd.clearIgnoredPeripherals",
           "when": "false"
         }
       ],
@@ -258,12 +276,22 @@
           "command": "peripheral-inspector.svd.exportAll",
           "when": "view =~ /peripheral-inspector.peripheral-*/ && debugState == stopped",
           "group": "navigation@4"
+        },
+        {
+          "command": "peripheral-inspector.svd.clearIgnoredPeripherals",
+          "when": "view =~ /peripheral-inspector.peripheral-*/ && debugState == stopped && peripheral-inspector.ignoredPeripheralsLength > 0",
+          "group": "more"
         }
       ],
       "webview/context": [
         {
           "command": "peripheral-inspector.svd.setFormat",
           "when": "webviewId =~ /peripheral-inspector.peripheral-*/ && webviewSection == tree-item",
+          "group": "navigation"
+        },
+        {
+          "command": "peripheral-inspector.svd.ignorePeripheral",
+          "when": "webviewId =~ /peripheral-inspector.peripheral-*/ && webviewSection == tree-item && cdtTreeItemType === peripheral-node",
           "group": "navigation"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -150,12 +150,12 @@
       },
       {
         "command": "peripheral-inspector.svd.ignorePeripheral",
-        "title": "Ignore Peripheral",
+        "title": "Ignore Peripheral (Workspace)",
         "icon": "$(circle-slash)"
       },
       {
         "command": "peripheral-inspector.svd.clearIgnoredPeripherals",
-        "title": "Clear Ignored Peripherals",
+        "title": "Clear Ignored Peripherals (Workspace)",
         "icon": "$(clear-all)"
       }
     ],

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -66,6 +66,13 @@ export interface IPeripheralsProvider {
     getPeripherals: (data: string, options: IGetPeripheralsArguments) => Promise<PeripheralOptions[]>;
 }
 
+export interface PeripheralsConfiguration {
+    gapThreshold: number;
+    peripheralOptions: Record<string, PeripheralOptions>;
+    enumTypeValues: Record<string, EnumerationMap>;
+    ignoredPeripherals: string[];
+}
+
 export enum AccessType {
     ReadOnly = 1,
     ReadWrite = 2,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -32,19 +32,23 @@ export class PeripheralCommands {
                     this.initIgnoredPeripheralsContext();
                 }
             }),
+
+            // VSCode specific commands
+            vscode.commands.registerCommand(Commands.FIND_COMMAND_ID, () => this.find()),
+            vscode.commands.registerCommand(Commands.SET_FORMAT_COMMAND_ID, (node) => this.peripheralsSetFormat(node)),
+            vscode.commands.registerCommand(Commands.REFRESH_ALL_COMMAND_ID, () => this.peripheralsForceRefresh()),
+            vscode.commands.registerCommand(Commands.COLLAPSE_ALL_COMMAND_ID, () => this.collapseAll()),
+            vscode.commands.registerCommand(Commands.EXPORT_ALL_COMMAND_ID, () => this.peripheralsExportAll()),
+            vscode.commands.registerCommand(Commands.IGNORE_PERIPHERAL_ID, (context) => this.ignorePeripheral(context)),
+            vscode.commands.registerCommand(Commands.CLEAR_IGNORED_PERIPHERAL_ID, () => this.clearIgnoredPeripherals()),
+
+            // Commands manually rendered in the DOM
             vscode.commands.registerCommand(Commands.UPDATE_NODE_COMMAND.commandId, (node, value) => this.peripheralsUpdateNode(node, value)),
             vscode.commands.registerCommand(Commands.EXPORT_NODE_COMMAND.commandId, node => this.peripheralsExportNode(node)),
             vscode.commands.registerCommand(Commands.COPY_VALUE_COMMAND.commandId, (node, value) => this.peripheralsCopyValue(node, value)),
-            vscode.commands.registerCommand(Commands.SET_FORMAT_COMMAND.commandId, (node) => this.peripheralsSetFormat(node)),
             vscode.commands.registerCommand(Commands.FORCE_REFRESH_COMMAND.commandId, (node) => this.peripheralsForceRefresh(node)),
             vscode.commands.registerCommand(Commands.PIN_COMMAND.commandId, (node, _, context) => this.peripheralsTogglePin(node, context)),
             vscode.commands.registerCommand(Commands.UNPIN_COMMAND.commandId, (node, _, context) => this.peripheralsTogglePin(node, context)),
-            vscode.commands.registerCommand(Commands.FIND_COMMAND.commandId, () => this.find()),
-            vscode.commands.registerCommand(Commands.REFRESH_ALL_COMMAND.commandId, () => this.peripheralsForceRefresh()),
-            vscode.commands.registerCommand(Commands.COLLAPSE_ALL_COMMAND.commandId, () => this.collapseAll()),
-            vscode.commands.registerCommand(Commands.EXPORT_ALL_COMMAND.commandId, () => this.peripheralsExportAll()),
-            vscode.commands.registerCommand(Commands.IGNORE_PERIPHERAL.commandId, (context) => this.ignorePeripheral(context)),
-            vscode.commands.registerCommand(Commands.CLEAR_IGNORED_PERIPHERAL.commandId, () => this.clearIgnoredPeripherals()),
         );
     }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,11 +25,11 @@ export class PeripheralCommands {
     }
 
     public async activate(context: vscode.ExtensionContext): Promise<void> {
-        this.initIgnoredPeripheralsContext();
+        this.updateIgnoredPeripheralsContext();
         context.subscriptions.push(
             vscode.workspace.onDidChangeConfiguration(e => {
                 if (e.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.IGNORE_PERIPHERALS}`)) {
-                    this.initIgnoredPeripheralsContext();
+                    this.updateIgnoredPeripheralsContext();
                 }
             }),
 
@@ -52,7 +52,7 @@ export class PeripheralCommands {
         );
     }
 
-    private initIgnoredPeripheralsContext(): void {
+    private updateIgnoredPeripheralsContext(): void {
         const ignoredPeripherals = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME)?.inspect<string[]>(manifest.IGNORE_PERIPHERALS)?.workspaceValue ?? [];
         vscode.commands.executeCommand('setContext', VSCodeContextKeys.IGNORED_PERIPHERALS_LENGTH, ignoredPeripherals.length);
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,6 +15,8 @@ import { PeripheralBaseNode } from './plugin/peripheral/nodes';
 import { PeripheralDataTracker } from './plugin/peripheral/tree/peripheral-data-tracker';
 import { PeripheralsTreeTableWebView } from './plugin/peripheral/webview/peripheral-tree-webview-main';
 import { getFilePath } from './fileUtils';
+import * as manifest from './manifest';
+import { VSCodeContextKeys } from './common/vscode-context';
 
 export class PeripheralCommands {
     public constructor(
@@ -23,7 +25,13 @@ export class PeripheralCommands {
     }
 
     public async activate(context: vscode.ExtensionContext): Promise<void> {
+        this.initIgnoredPeripheralsContext();
         context.subscriptions.push(
+            vscode.workspace.onDidChangeConfiguration(e => {
+                if (e.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.IGNORE_PERIPHERALS}`)) {
+                    this.initIgnoredPeripheralsContext();
+                }
+            }),
             vscode.commands.registerCommand(Commands.UPDATE_NODE_COMMAND.commandId, (node, value) => this.peripheralsUpdateNode(node, value)),
             vscode.commands.registerCommand(Commands.EXPORT_NODE_COMMAND.commandId, node => this.peripheralsExportNode(node)),
             vscode.commands.registerCommand(Commands.COPY_VALUE_COMMAND.commandId, (node, value) => this.peripheralsCopyValue(node, value)),
@@ -35,7 +43,14 @@ export class PeripheralCommands {
             vscode.commands.registerCommand(Commands.REFRESH_ALL_COMMAND.commandId, () => this.peripheralsForceRefresh()),
             vscode.commands.registerCommand(Commands.COLLAPSE_ALL_COMMAND.commandId, () => this.collapseAll()),
             vscode.commands.registerCommand(Commands.EXPORT_ALL_COMMAND.commandId, () => this.peripheralsExportAll()),
+            vscode.commands.registerCommand(Commands.IGNORE_PERIPHERAL.commandId, (context) => this.ignorePeripheral(context)),
+            vscode.commands.registerCommand(Commands.CLEAR_IGNORED_PERIPHERAL.commandId, () => this.clearIgnoredPeripherals()),
         );
+    }
+
+    private initIgnoredPeripheralsContext(): void {
+        const ignoredPeripherals = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME)?.inspect<string[]>(manifest.IGNORE_PERIPHERALS)?.workspaceValue ?? [];
+        vscode.commands.executeCommand('setContext', VSCodeContextKeys.IGNORED_PERIPHERALS_LENGTH, ignoredPeripherals.length);
     }
 
     private async peripheralsUpdateNode(node: PeripheralBaseNode, value?: unknown): Promise<void> {
@@ -122,5 +137,16 @@ export class PeripheralCommands {
 
     private peripheralsTogglePin(node: PeripheralBaseNode, context?: TreeNotificationContext): void {
         this.dataTracker.togglePin(node, context);
+    }
+
+    private ignorePeripheral(context: CTDTreeWebviewContext): void {
+        const node = this.dataTracker.getNodeByPath(context.cdtTreeItemId.split(PERIPHERAL_ID_SEP));
+
+        const ignoredPeripherals = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<string[]>(manifest.IGNORE_PERIPHERALS) ?? [];
+        vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).update(manifest.IGNORE_PERIPHERALS, [...ignoredPeripherals, node.name]);
+    }
+
+    private clearIgnoredPeripherals(): void {
+        vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).update(manifest.IGNORE_PERIPHERALS, undefined);
     }
 }

--- a/src/common/peripheral-dto.ts
+++ b/src/common/peripheral-dto.ts
@@ -68,7 +68,7 @@ export interface PeripheralSessionNodeDTO extends PeripheralBaseNodeDTO {
     children: Array<PeripheralNodeDTO>;
 }
 export namespace PeripheralSessionNodeDTO {
-    export const Type = 'PeripheralSessionNode';
+    export const Type = 'peripheral-session-node';
 
     export function is(node: object): node is PeripheralSessionNodeDTO {
         return PeripheralBaseTreeNodeDTO.hasType(node, Type);
@@ -90,7 +90,7 @@ export interface PeripheralNodeDTO extends PeripheralBaseNodeDTO, PeripheralOpti
     groupName: string;
 }
 export namespace PeripheralNodeDTO {
-    export const Type = 'PeripheralNode';
+    export const Type = 'peripheral-node';
 
     export function is(node: object): node is PeripheralNodeDTO {
         return PeripheralBaseTreeNodeDTO.hasType(node, Type);
@@ -110,7 +110,7 @@ export interface ClusterOrRegisterBaseNodeDTO extends PeripheralBaseNodeDTO {
     offset: number | undefined;
 }
 export namespace ClusterOrRegisterBaseNodeDTO {
-    export const Type = 'ClusterOrRegisterBaseNode';
+    export const Type = 'cluster-or-register-base-node';
 
     export function is(node: object): node is ClusterOrRegisterBaseNodeDTO {
         return PeripheralBaseTreeNodeDTO.hasType(node, Type);
@@ -132,7 +132,7 @@ export interface PeripheralClusterNodeDTO extends ClusterOrRegisterBaseNodeDTO, 
     offset: number;
 }
 export namespace PeripheralClusterNodeDTO {
-    export const Type = 'PeripheralClusterNode';
+    export const Type = 'peripheral-cluster-node';
 
     export function is(node: object): node is PeripheralClusterNodeDTO {
         return PeripheralBaseTreeNodeDTO.hasType(node, Type);
@@ -156,7 +156,7 @@ export interface PeripheralFieldNodeDTO extends PeripheralBaseNodeDTO, FieldOpti
     resetValue: number;
 }
 export namespace PeripheralFieldNodeDTO {
-    export const Type = 'PeripheralFieldNode';
+    export const Type = 'peripheral-field-node';
 
     export function is(node: object): node is PeripheralFieldNodeDTO {
         return PeripheralBaseTreeNodeDTO.hasType(node, Type);
@@ -184,7 +184,7 @@ export interface PeripheralRegisterNodeDTO extends ClusterOrRegisterBaseNodeDTO,
     address: number;
 }
 export namespace PeripheralRegisterNodeDTO {
-    export const Type = 'PeripheralRegisterNode';
+    export const Type = 'peripheral-register-node';
 
     export function is(node: object): node is PeripheralRegisterNodeDTO {
         return PeripheralBaseTreeNodeDTO.hasType(node, Type);

--- a/src/common/vscode-context.ts
+++ b/src/common/vscode-context.ts
@@ -1,0 +1,12 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License as outlined in the LICENSE File
+ ********************************************************************************/
+
+import { PACKAGE_NAME } from '../manifest';
+
+export namespace VSCodeContextKeys {
+    export const IGNORED_PERIPHERALS_LENGTH = `${PACKAGE_NAME}.ignoredPeripheralsLength`;
+}

--- a/src/common/vscode.ts
+++ b/src/common/vscode.ts
@@ -28,6 +28,9 @@ export interface NodeSetting {
     pinned?: boolean;
 }
 
+/**
+ * A command definition that is manually inserted into the DOM and not by VSCode.
+ */
 export interface CommandDefinition {
     commandId: string;
     icon: string;

--- a/src/components/tree/components/expand-icon.tsx
+++ b/src/components/tree/components/expand-icon.tsx
@@ -4,7 +4,7 @@
  * This program and the accompanying materials are made available under the
  * terms of the MIT License as outlined in the LICENSE File
  ********************************************************************************/
-import { CDTTreeItem } from '../types';
+import { CDTTreeItem, CDTTreeItemResource } from '../types';
 import { classNames } from './utils';
 import React from 'react';
 
@@ -18,7 +18,7 @@ export interface RenderExpandIconProps<RecordType> {
 
 export type TriggerEventHandler<RecordType> = (record: RecordType, event: React.MouseEvent<HTMLElement>) => void;
 
-export function ExpandIcon({ expanded, onExpand, record, expandable }: RenderExpandIconProps<CDTTreeItem>): React.ReactElement {
+export function ExpandIcon<T extends CDTTreeItemResource>({ expanded, onExpand, record, expandable }: RenderExpandIconProps<CDTTreeItem<T>>): React.ReactElement {
     if (!expandable) {
         // simulate spacing to the left that we gain through expand icon so that leaf items look correctly intended
         return <span className='leaf-item-spacer' />;

--- a/src/components/tree/components/treetable-navigator.tsx
+++ b/src/components/tree/components/treetable-navigator.tsx
@@ -4,22 +4,22 @@
  * This program and the accompanying materials are made available under the
  * terms of the MIT License as outlined in the LICENSE File
  ********************************************************************************/
-import { CDTTreeItem } from '../types';
+import { CDTTreeItem, CDTTreeItemResource } from '../types';
 
-export interface TreeNavigatorProps {
+export interface TreeNavigatorProps<T extends CDTTreeItemResource> {
     ref: React.RefObject<HTMLDivElement>;
     rowIndex: Map<string, number>;
     expandedRowKeys: string[];
-    expand: (expanded: boolean, record: CDTTreeItem) => void;
-    select: (record: CDTTreeItem) => void;
+    expand: (expanded: boolean, record: CDTTreeItem<T>) => void;
+    select: (record: CDTTreeItem<T>) => void;
 }
 
 /**
  * TreeNavigator is a helper class to navigate
  * through a tree table.
  */
-export class TreeNavigator {
-    constructor(private readonly props: TreeNavigatorProps) {
+export class TreeNavigator<T extends CDTTreeItemResource = CDTTreeItemResource> {
+    constructor(private readonly props: TreeNavigatorProps<T>) {
     }
 
     next(node: CDTTreeItem) {
@@ -104,14 +104,14 @@ export class TreeNavigator {
             if (this.props.expandedRowKeys.includes(node.id)) {
                 this.next(node);
             } else {
-                this.props.expand(true, node);
+                this.props.expand(true, node as CDTTreeItem<T>);
             }
         }
     }
 
     collapse(node: CDTTreeItem) {
         if (node.children && node.children.length > 0 && this.props.expandedRowKeys.includes(node.id)) {
-            this.props.expand(false, node);
+            this.props.expand(false, node as CDTTreeItem<T>);
         } else if (node.parent && !CDTTreeItem.isRoot(node.parent)) {
             this.select(node.parent, 'absolute');
         }
@@ -122,16 +122,16 @@ export class TreeNavigator {
         if (!this.isDomVisible(node)) {
             if (scrollMode === 'absolute') {
                 this.scrollAbsolute(node);
-                this.props.select(node);
+                this.props.select(node as CDTTreeItem<T>);
             } else {
                 this.scrollRelative(-(this.visibleDomElementCount / 2));
             }
 
-            this.props.select(node);
+            this.props.select(node as CDTTreeItem<T>);
             // Allow the DOM to update before focusing
             setTimeout(() => this.getDomElement(node)?.focus(), 100);
         } else {
-            this.props.select(node);
+            this.props.select(node as CDTTreeItem<T>);
             this.getDomElement(node)?.focus();
         }
 

--- a/src/components/tree/components/utils.tsx
+++ b/src/components/tree/components/utils.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../tooltip/tooltip';
-import { CDTTreeItem, CDTTreeTableStringColumn } from '../types';
+import { CDTTreeItem, CDTTreeItemResource, CDTTreeTableStringColumn } from '../types';
 
 export function classNames(...classes: (string | Record<string, boolean>)[]): string {
     return classes.filter(c => c !== undefined).map(c => {
@@ -75,7 +75,7 @@ export function createLabelWithTooltip(child: React.JSX.Element, tooltip?: strin
  * and their ancestor hierarchy. If children are not to be filtered, all children
  * of a matched item are included. Elements that match the search text are marked.
  */
-export function filterTree<T>(
+export function filterTree<T extends CDTTreeItemResource>(
     items: CDTTreeItem<T>[],
     searchText: string,
     options: { filterChildren?: boolean } = { filterChildren: false }
@@ -117,7 +117,7 @@ export function filterTree<T>(
 /**
  * Options for traversing the tree.
  */
-export interface TraverseOptions<T, U> {
+export interface TraverseOptions<T extends CDTTreeItemResource, U> {
     /**
      * A predicate function to determine if an item should be included.
      * If omitted, all items are included.
@@ -138,7 +138,7 @@ export interface TraverseOptions<T, U> {
  * @param options - Optional traversal options including predicate and mapFn.
  * @returns An array of items that satisfy the predicate and are optionally mapped.
  */
-export function traverseTree<T, U = CDTTreeItem<T>>(
+export function traverseTree<T extends CDTTreeItemResource, U = CDTTreeItem<T>>(
     items: CDTTreeItem<T>[],
     options?: TraverseOptions<T, U>
 ): U[] {
@@ -168,11 +168,11 @@ export function traverseTree<T, U = CDTTreeItem<T>>(
     return result;
 }
 
-export function getAncestors<T>(
+export function getAncestors<T extends CDTTreeItemResource>(
     item: CDTTreeItem<T>
-): CDTTreeItem<unknown>[] {
-    const ancestors: CDTTreeItem<unknown>[] = [];
-    let current: CDTTreeItem<unknown> | undefined = item.parent;
+): CDTTreeItem<CDTTreeItemResource>[] {
+    const ancestors: CDTTreeItem<CDTTreeItemResource>[] = [];
+    let current: CDTTreeItem<CDTTreeItemResource> | undefined = item.parent;
     while (current) {
         ancestors.push(current);
         current = current.parent as unknown as CDTTreeItem<T>;

--- a/src/components/tree/integration/peripheral-tree-converter.ts
+++ b/src/components/tree/integration/peripheral-tree-converter.ts
@@ -8,7 +8,7 @@
 import { AccessType } from '../../../api-types';
 import { CommandDefinition } from '../../../common';
 import { formatValue, NumberFormat } from '../../../common/format';
-import { PeripheralClusterNodeDTO, PeripheralFieldNodeContextValue, PeripheralFieldNodeDTO, PeripheralNodeDTO, PeripheralRegisterNodeDTO, PeripheralSessionNodeDTO, PeripheralTreeNodeDTOs } from '../../../common/peripheral-dto';
+import { PeripheralBaseNodeDTO, PeripheralClusterNodeDTO, PeripheralFieldNodeContextValue, PeripheralFieldNodeDTO, PeripheralNodeDTO, PeripheralRegisterNodeDTO, PeripheralSessionNodeDTO, PeripheralTreeNodeDTOs } from '../../../common/peripheral-dto';
 import { Commands } from '../../../manifest';
 import { binaryFormat, extractBits, hexFormat } from '../../../utils';
 import { CDTTreeItem, CDTTreeTableActionColumnCommand, CDTTreeTableColumn } from '../types';
@@ -18,6 +18,7 @@ import { TreeConverterContext, TreeResourceConverter } from './tree-converter';
 export class PeripheralTreeConverter implements TreeResourceConverter<PeripheralTreeNodeDTOs> {
 
     protected converters: TreeResourceConverter<PeripheralTreeNodeDTOs>[] = [
+        new PeripheralBaseNodeConverter(),
         new PeripheralSessionNodeConverter(),
         new PeripheralNodeConverter(),
         new PeripheralClusterNodeConverter(),
@@ -50,8 +51,38 @@ export class PeripheralTreeConverter implements TreeResourceConverter<Peripheral
             return item;
         }
 
-        throw new Error('No converter found for peripheral: ' + resource.__type);
+        throw new Error(`No converter found for peripheral: ${resource.__type}, ${JSON.stringify(resource)}`);
 
+    }
+}
+
+
+export class PeripheralBaseNodeConverter implements TreeResourceConverter<PeripheralBaseNodeDTO, PeripheralTreeNodeDTOs> {
+    canHandle(resource: PeripheralTreeNodeDTOs): boolean {
+        return PeripheralBaseNodeDTO.is(resource);
+    }
+
+    convert(resource: PeripheralBaseNodeDTO, context: TreeConverterContext<PeripheralTreeNodeDTOs>): CDTTreeItem<PeripheralBaseNodeDTO> {
+        return CDTTreeItem.create({
+            id: resource.id,
+            key: resource.id,
+            parent: context.parent,
+            resource,
+            expanded: context.expandedKeys.includes(resource.id),
+            columns: this.getColumns(resource, context),
+        });
+    }
+
+    // ==== Rendering ====
+
+    private getColumns(resource: PeripheralBaseNodeDTO, _context: TreeConverterContext<PeripheralTreeNodeDTOs>): Record<string, CDTTreeTableColumn> {
+        return {
+            'title': {
+                type: 'string',
+                label: resource.name,
+                colSpan: 'fill'
+            },
+        };
     }
 }
 

--- a/src/components/tree/integration/tree-converter.ts
+++ b/src/components/tree/integration/tree-converter.ts
@@ -5,15 +5,15 @@
  * terms of the MIT License as outlined in the LICENSE File
  ********************************************************************************/
 
-import { CDTTreeItem } from '../types';
+import { CDTTreeItem, CDTTreeItemResource } from '../types';
 
 /**
  * A TreeConverterContext is used to pass additional information to the TreeResourceConverter.
  * It contains the expanded keys, pinned keys and a resource map.
  * It will be propagated to all TreeResourceConverters.
  */
-export interface TreeConverterContext<TResource = unknown> {
-    parent?: CDTTreeItem<unknown>,
+export interface TreeConverterContext<TResource extends CDTTreeItemResource = CDTTreeItemResource> {
+    parent?: CDTTreeItem<CDTTreeItemResource>,
     /**
      * The expanded keys of the tree. This is used to determine if a node should be expanded or not.
      */
@@ -33,7 +33,7 @@ export interface TreeConverterContext<TResource = unknown> {
 /**
  * A TreeResourceConverter is responsible for converting a resource into a CDTTreeItem.
  */
-export interface TreeResourceConverter<TResource = unknown, TContextResource = TResource> {
+export interface TreeResourceConverter<TResource extends CDTTreeItemResource, TContextResource extends CDTTreeItemResource = TResource> {
     canHandle(resource: TResource): boolean;
 
     convert(resource: TResource, context: TreeConverterContext<TContextResource>): CDTTreeItem<TResource>;

--- a/src/components/tree/types.ts
+++ b/src/components/tree/types.ts
@@ -11,14 +11,18 @@ import { TreeNotification } from '../../common/notification';
 
 // ==== Items ====
 
+export interface CDTTreeItemResource {
+    __type: string;
+}
+
 /**
  * A tree item that is used in the CDT tree view.
  */
-export interface CDTTreeItem<T = unknown> {
+export interface CDTTreeItem<T extends CDTTreeItemResource = CDTTreeItemResource> {
     __type: 'CDTTreeItem'
     id: string;
     key: string;
-    parent?: CDTTreeItem<unknown>;
+    parent?: CDTTreeItem<CDTTreeItemResource> | undefined;
     children?: CDTTreeItem<T>[];
     /**
      * The resource that this tree item represents. This can be any type of object.
@@ -43,18 +47,18 @@ export interface CDTTreeItem<T = unknown> {
 }
 
 export namespace CDTTreeItem {
-    export function create<TResource>(options: Omit<CDTTreeItem<TResource>, '__type'>): CDTTreeItem<TResource> {
+    export function create<TResource extends CDTTreeItemResource>(options: Omit<CDTTreeItem<TResource>, '__type'>): CDTTreeItem<TResource> {
         return {
             __type: 'CDTTreeItem',
             ...options
         };
     }
 
-    export function createRoot(): CDTTreeItem<unknown> {
-        return create<unknown>({
+    export function createRoot(): CDTTreeItem<CDTTreeItemResource> {
+        return create<CDTTreeItemResource>({
             id: 'root',
             key: 'root',
-            resource: undefined,
+            resource: { __type: 'root' },
             children: []
         });
     }
@@ -134,7 +138,7 @@ export interface CDTTreeExtensionModel<TItems = unknown> {
  * The view model that is used to update the CDT tree view.
  * It is the actual model that is used to render the tree view.
  */
-export interface CDTTreeViewModel<TItem = unknown> {
+export interface CDTTreeViewModel<TItem extends CDTTreeItemResource = CDTTreeItemResource> {
     items: CDTTreeItem<TItem>[];
     expandedKeys: string[];
     pinnedKeys: string[];
@@ -144,6 +148,7 @@ export interface CDTTreeViewModel<TItem = unknown> {
 export interface CTDTreeWebviewContext {
     webviewSection: string;
     cdtTreeItemId: string;
+    cdtTreeItemType: string;
 }
 
 export namespace CTDTreeWebviewContext {

--- a/src/components/tree/types.ts
+++ b/src/components/tree/types.ts
@@ -22,7 +22,7 @@ export interface CDTTreeItem<T extends CDTTreeItemResource = CDTTreeItemResource
     __type: 'CDTTreeItem'
     id: string;
     key: string;
-    parent?: CDTTreeItem<CDTTreeItemResource> | undefined;
+    parent?: CDTTreeItem<CDTTreeItemResource>;
     children?: CDTTreeItem<T>[];
     /**
      * The resource that this tree item represents. This can be any type of object.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -79,6 +79,16 @@ export namespace Commands {
         icon: 'desktop-download',
         title: 'Export All'
     } as const;
+    export const IGNORE_PERIPHERAL: CommandDefinition = {
+        commandId: `${PACKAGE_NAME}.svd.ignorePeripheral`,
+        icon: 'circle-slash',
+        title: 'Ignore Peripheral'
+    } as const;
+    export const CLEAR_IGNORED_PERIPHERAL: CommandDefinition = {
+        commandId: `${PACKAGE_NAME}.svd.clearIgnoredPeripherals`,
+        icon: 'clear-all',
+        title: 'Clear Ignored Peripheral'
+    } as const;
 }
 
 export namespace IgnorePeripherals {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -24,6 +24,16 @@ export const DEFAULT_SAVE_LAYOUT = true;
 
 // Commands
 export namespace Commands {
+    // Commands used only within VSCode
+    export const SET_FORMAT_COMMAND_ID = `${PACKAGE_NAME}.svd.setFormat`;
+    export const FIND_COMMAND_ID = `${PACKAGE_NAME}.svd.find`;
+    export const REFRESH_ALL_COMMAND_ID = `${PACKAGE_NAME}.svd.refreshAll`;
+    export const COLLAPSE_ALL_COMMAND_ID = `${PACKAGE_NAME}.svd.collapseAll`;
+    export const EXPORT_ALL_COMMAND_ID = `${PACKAGE_NAME}.svd.exportAll`;
+    export const IGNORE_PERIPHERAL_ID = `${PACKAGE_NAME}.svd.ignorePeripheral`;
+    export const CLEAR_IGNORED_PERIPHERAL_ID = `${PACKAGE_NAME}.svd.clearIgnoredPeripherals`;
+
+    // Commands used in the UI. They are manually inserted into the DOM.
     export const UPDATE_NODE_COMMAND: CommandDefinition = {
         commandId: `${PACKAGE_NAME}.svd.updateNode`,
         icon: 'edit',
@@ -39,11 +49,6 @@ export namespace Commands {
         icon: 'files',
         title: 'Copy Value'
     } as const;
-    export const SET_FORMAT_COMMAND: CommandDefinition = {
-        commandId: `${PACKAGE_NAME}.svd.setFormat`,
-        icon: 'symbol-unit',
-        title: 'Set Value Format'
-    } as const;
     export const FORCE_REFRESH_COMMAND: CommandDefinition = {
         commandId: `${PACKAGE_NAME}.svd.forceRefresh`,
         icon: 'refresh',
@@ -58,36 +63,6 @@ export namespace Commands {
         commandId: `${PACKAGE_NAME}.svd.unpin`,
         icon: 'pinned',
         title: 'Unpin'
-    } as const;
-    export const FIND_COMMAND: CommandDefinition = {
-        commandId: `${PACKAGE_NAME}.svd.find`,
-        icon: 'search',
-        title: 'Find'
-    } as const;
-    export const REFRESH_ALL_COMMAND: CommandDefinition = {
-        commandId: `${PACKAGE_NAME}.svd.refreshAll`,
-        icon: 'refresh',
-        title: 'Refresh All'
-    } as const;
-    export const COLLAPSE_ALL_COMMAND: CommandDefinition = {
-        commandId: `${PACKAGE_NAME}.svd.collapseAll`,
-        icon: 'collapse-all',
-        title: 'Collapse All'
-    } as const;
-    export const EXPORT_ALL_COMMAND: CommandDefinition = {
-        commandId: `${PACKAGE_NAME}.svd.exportAll`,
-        icon: 'desktop-download',
-        title: 'Export All'
-    } as const;
-    export const IGNORE_PERIPHERAL: CommandDefinition = {
-        commandId: `${PACKAGE_NAME}.svd.ignorePeripheral`,
-        icon: 'circle-slash',
-        title: 'Ignore Peripheral'
-    } as const;
-    export const CLEAR_IGNORED_PERIPHERAL: CommandDefinition = {
-        commandId: `${PACKAGE_NAME}.svd.clearIgnoredPeripherals`,
-        icon: 'clear-all',
-        title: 'Clear Ignored Peripheral'
     } as const;
 }
 

--- a/src/plugin/peripheral/nodes/message-node.ts
+++ b/src/plugin/peripheral/nodes/message-node.ts
@@ -37,7 +37,9 @@ export class MessageNode extends PeripheralBaseNode {
         return CDTTreeItem.create({
             id: this.getId(),
             key: this.getId(),
-            resource: undefined,
+            resource: {
+                __type: 'message'
+            },
         });
     }
 

--- a/src/plugin/peripheral/nodes/message-node.ts
+++ b/src/plugin/peripheral/nodes/message-node.ts
@@ -7,7 +7,7 @@
 
 import * as vscode from 'vscode';
 import { AddrRange } from '../../../addrranges';
-import { NodeSetting } from '../../../common';
+import { NodeSetting, PeripheralBaseNodeDTO } from '../../../common';
 import { CDTTreeItem } from '../../../components/tree/types';
 import { PeripheralBaseNode } from './base-node';
 
@@ -71,5 +71,12 @@ export class MessageNode extends PeripheralBaseNode {
 
     public findByPath(_path: string[]): PeripheralBaseNode | undefined {
         return undefined;
+    }
+
+    serialize(): PeripheralBaseNodeDTO {
+        return PeripheralBaseNodeDTO.create({
+            ...super.serialize(),
+            name: this.message,
+        });
     }
 }

--- a/src/plugin/peripheral/tree/peripheral-session-tree.ts
+++ b/src/plugin/peripheral/tree/peripheral-session-tree.ts
@@ -50,20 +50,10 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
         super();
         this.name = this.session.name;
         this.expanded = expanded;
-
-        this.init();
     }
 
     public getId(): string {
         return this.session.id;
-    }
-
-    private init(): void {
-        vscode.workspace.onDidChangeConfiguration(e => {
-            if (e.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.IGNORE_PERIPHERALS}`)) {
-                this.reloadIgnoredPeripherals();
-            }
-        });
     }
 
     private static getStatePropName(session: vscode.DebugSession): string {
@@ -235,7 +225,7 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
     /**
      * Reload allows the session to filter out peripherals that are in the ignore list or include them again.
      */
-    private async reloadIgnoredPeripherals(): Promise<void> {
+    async reloadIgnoredPeripherals(): Promise<void> {
         if (!this.loaded || !this.peripheralsConfiguration) {
             // Do nothing
             return;
@@ -260,11 +250,11 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
             this.peripherals.sort(PeripheralNodeSort.compare);
         }
 
+        this.refresh();
+
         if (this.svdUri) {
             await PeripheralTreeForSession.addToCache(this.svdUri, this.peripherals, this.peripheralsConfiguration);
         }
-
-        this.refresh();
     }
 
     public performUpdate(): Thenable<boolean> {


### PR DESCRIPTION
Closes #39 

- Allows to change the ignored peripherals at runtime
- Adds context menu entries (Workspace settings)
- Allows to clear those (Workspace settings)

Follow up improvements:
- Performance: Send only partial updates from the extension to the webview.
