### PR TITLE
Allow inline editing of values

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -128,14 +128,13 @@ export class PeripheralCommands {
 
     private async peripheralsForceRefresh(node?: PeripheralBaseNode): Promise<void> {
         if (node) {
-            const p = node.getPeripheral();
-            if (p) {
-                await p.updateData();
+            const peripheral = node.getPeripheral();
+            if (peripheral) {
+                await peripheral.updateData();
             }
-
             this.dataTracker.fireOnDidChange();
         } else {
-            await this.dataTracker.updateData();
+            return this.dataTracker.updateData();
         }
     }
 

--- a/src/components/tree/components/cells/ActionCell.tsx
+++ b/src/components/tree/components/cells/ActionCell.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { CDTTreeTableActionColumn, CDTTreeItem, CDTTreeTableActionColumnCommand, CDTTreeItemResource } from '../../types';
+import { CommandDefinition } from '../../../../common';
+
+export interface ActionCellProps<T extends CDTTreeItemResource> {
+    column: CDTTreeTableActionColumn;
+    record: CDTTreeItem<T>;
+    actions: CDTTreeTableActionColumnCommand[];
+    onAction?: (event: React.UIEvent, command: CommandDefinition, value: unknown, record: CDTTreeItem<T>) => void;
+}
+
+const ActionCell = <T extends CDTTreeItemResource>({ record, actions, onAction }: ActionCellProps<T>) => {
+    return (
+        <div className="tree-actions">
+            {actions.map((action) => {
+                const handleAction = (e: React.MouseEvent | React.KeyboardEvent) => onAction?.(e, action, action.value, record);
+                return (
+                    <i
+                        key={action.commandId}
+                        title={action.title}
+                        className={`codicon codicon-${action.icon}`}
+                        onClick={handleAction}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => e.key === 'Enter' && handleAction(e)}
+                    />
+                );
+            })}
+        </div>
+    );
+};
+
+export default ActionCell;

--- a/src/components/tree/components/cells/EditableStringCell.tsx
+++ b/src/components/tree/components/cells/EditableStringCell.tsx
@@ -1,0 +1,157 @@
+import './editable-string-cell.css';
+
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { Input, Checkbox, Select } from 'antd';
+import type { CheckboxChangeEvent } from 'antd/lib/checkbox';
+import LabelCell from './LabelCell';
+import { CDTTreeTableStringColumn, CDTTreeItem, EditableEnumData, CDTTreeItemResource } from '../../types';
+
+interface EditableLabelCellProps<T extends CDTTreeItemResource> {
+    column: CDTTreeTableStringColumn;
+    record: CDTTreeItem<T>;
+    editing: boolean;
+    onSubmit: (newValue: string) => void;
+    onCancel: () => void;
+}
+
+const EditableLabelCell = <T extends CDTTreeItemResource>({
+    column,
+    record,
+    editing,
+    onSubmit,
+    onCancel
+}: EditableLabelCellProps<T>) => {
+    const [editMode, setEditMode] = useState(editing);
+    const [value, setValue] = useState(column.label);
+    const containerRef = useRef<HTMLDivElement>(null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editorRef = useRef<any>(null);
+
+    // Focus the editor when entering edit mode.
+    useEffect(() => {
+        if (editMode && editorRef.current) {
+            editorRef.current.focus();
+        }
+    }, [editMode]);
+
+    const commitEdit = useCallback((newValue: string = value) => {
+        setValue(newValue);
+        onSubmit(newValue);
+        setEditMode(false);
+    }, [onSubmit, value]);
+
+    const cancelEdit = useCallback(() => {
+        setValue(column.label);
+        onCancel();
+        setEditMode(false);
+    }, [column.label]);
+
+    // Cancel the edit only if focus leaves the entire container.
+    const handleBlur = useCallback(() => {
+        setTimeout(() => {
+            if (
+                containerRef.current &&
+                document.activeElement &&
+                !containerRef.current.contains(document.activeElement)
+            ) {
+                cancelEdit();
+            }
+        }, 0);
+    }, [column.label]);
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                cancelEdit();
+            }
+        },
+        [column.label]
+    );
+
+    // Consume the double-click event so no other handler is triggered.
+    const handleDoubleClick = useCallback((e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (column.edit) {
+            setEditMode(true);
+        }
+    }, [column]);
+
+    useEffect(() => {
+        if (editMode || editing) {
+            editorRef.current && editorRef.current.focus();
+        }
+    }, [editMode, editing]);
+
+    if (editMode || editing) {
+        return (
+            <div className='edit-field-container' ref={containerRef}>
+                {(() => {
+                    switch (column.edit?.type) {
+                        case 'text':
+                            return (
+                                <Input
+                                    ref={editorRef}
+                                    className={'text-field-cell'}
+                                    value={value}
+                                    onChange={e => setValue(e.target.value)}
+                                    onPressEnter={e => commitEdit(e.currentTarget.value)}
+                                    onBlur={handleBlur}
+                                    onKeyDown={handleKeyDown}
+                                />
+                            );
+                        case 'boolean': {
+                            const checked = value === '1';
+                            return (
+                                <Checkbox
+                                    ref={editorRef}
+                                    checked={checked}
+                                    onChange={(e: CheckboxChangeEvent) => commitEdit(e.target.checked ? '1' : '0')}
+                                    onBlur={handleBlur}
+                                    onKeyDown={handleKeyDown}
+                                />
+                            );
+                        }
+                        case 'enum': {
+                            const enumEdit = column.edit as EditableEnumData;
+                            return (
+                                <Select
+                                    ref={editorRef}
+                                    className={'enum-field-cell'}
+                                    placeholder={column.label}
+                                    value={value}
+                                    onChange={(newValue) => commitEdit(newValue)}
+                                    onBlur={handleBlur}
+                                    onKeyDown={handleKeyDown}
+                                >
+                                    {enumEdit.options.map((opt) => {
+                                        const label = opt.value + (opt.detail ? `: ${opt.detail}` : '');
+                                        return (
+                                            <Select.Option key={opt.value} value={opt.value}>
+                                                {label}
+                                            </Select.Option>
+                                        );
+                                    })}
+                                </Select>
+                            );
+                        }
+                        default:
+                            return null;
+                    }
+                })()}
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className='editable-string-cell'
+            onDoubleClick={handleDoubleClick}
+            style={{ cursor: column.edit ? 'pointer' : 'default' }}
+        >
+            <LabelCell record={record} column={column} />
+        </div>
+    );
+};
+
+export default React.memo(EditableLabelCell);

--- a/src/components/tree/components/cells/LabelCell.tsx
+++ b/src/components/tree/components/cells/LabelCell.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import classNames from 'classnames';
+import { CDTTreeTableStringColumn, CDTTreeItem, CDTTreeItemResource } from '../../types';
+import { createLabelWithTooltip, createHighlightedText } from '../utils';
+
+export interface LabelCellProps<T extends CDTTreeItemResource> {
+    column: CDTTreeTableStringColumn;
+    record: CDTTreeItem<T>;
+}
+
+const LabelCell = <T extends CDTTreeItemResource>({ column }: LabelCellProps<T>) => {
+    const icon = column.icon && <i className={classNames('cell-icon', column.icon)} />;
+
+    const content = column.tooltip
+        ? createLabelWithTooltip(<span>{createHighlightedText(column.label, column.highlight)}</span>, column.tooltip)
+        : createHighlightedText(column.label, column.highlight);
+
+    return (
+        <div className="tree-cell ant-table-cell-ellipsis" tabIndex={0}>
+            {icon}
+            {content}
+        </div>
+    );
+};
+
+export default React.memo(LabelCell);

--- a/src/components/tree/components/cells/StringCell.tsx
+++ b/src/components/tree/components/cells/StringCell.tsx
@@ -1,0 +1,30 @@
+import React, { useCallback } from 'react';
+import { CDTTreeItem, CDTTreeItemResource, CDTTreeTableStringColumn } from '../../types';
+import EditableStringCell from './EditableStringCell';
+import LabelCell from './LabelCell';
+
+interface StringCellProps<T extends CDTTreeItemResource> {
+    column: CDTTreeTableStringColumn;
+    record: CDTTreeItem<T>;
+    editing?: boolean;
+    onSubmit?: (record: CDTTreeItem<T>, newValue: string) => void;
+    onCancel?: (record: CDTTreeItem<T>) => void;
+}
+
+const StringCell = <T extends CDTTreeItemResource>({ column, record, editing = false, onSubmit, onCancel }: StringCellProps<T>) => {
+    const handleSubmit = useCallback(
+        (newValue: string) => onSubmit?.(record, newValue),
+        [record, onSubmit]
+    );
+
+    const handleCancel = useCallback(
+        () => onCancel?.(record),
+        [record, onCancel]
+    );
+
+    return column.edit && onSubmit
+        ? <EditableStringCell record={record} column={column} onSubmit={handleSubmit} onCancel={handleCancel} editing={editing} />
+        : <LabelCell record={record} column={column} />;
+};
+
+export default StringCell;

--- a/src/components/tree/components/cells/editable-string-cell.css
+++ b/src/components/tree/components/cells/editable-string-cell.css
@@ -1,0 +1,79 @@
+/*********************************************************************
+ * Copyright (c) 2024 Arm Limited and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+.ant-input.text-field-cell {
+  background: var(--ant-color-bg-container);
+  color: var(--ant-color-text);
+  font-family: var(--ant-font-family-code);
+  font-size: var(--ant-table-cell-font-size);
+  line-height: var(--ant-line-height);
+  padding: 1px;
+  padding-left: 3px;
+  border-radius: 0;
+  border-style: dotted;
+}
+
+.css-var-r0.ant-select-css-var {
+  --ant-control-height: auto;
+  --ant-color-text-placeholder: var(--vscode-sideBar-foreground);
+  --ant-select-show-arrow-padding-inline-end: 2em;
+  --ant-border-radius-sm: 0;
+  --ant-border-radius-lg: 0;
+  --ant-select-option-active-bg: var(--vscode-list-hoverBackground);
+  --ant-select-option-font-size: 12px;
+  --ant-select-option-selected-bg: var(--vscode-list-inactiveSelectionBackground);
+  --ant-select-option-selected-color: var(--vscode-sideBar-foreground);
+  --ant-select-option-height: auto;
+  --ant-select-option-padding: 3px 6px;
+}
+
+.enum-field-cell.ant-select-outlined:not(.ant-select-customize-input) .ant-select-selector {
+  background: var(--ant-color-bg-container);
+  color: var(--ant-color-text);
+  font-family: var(--ant-font-family-code);
+  font-size: var(--ant-table-cell-font-size);
+  line-height: var(--ant-line-height);
+  padding: 1px;
+  padding-left: 3px;
+  border-radius: 0;
+  border-style: dotted;
+}
+
+.ant-select-dropdown {
+  background: var(--ant-color-bg-container);
+  color: var(--ant-color-text);
+  font-family: var(--ant-font-family-code);
+  font-size: var(--ant-table-cell-font-size);
+  line-height: var(--ant-line-height);
+  padding: 1px;
+  padding-left: 3px;
+}
+
+.enum-field-cell.ant-select-outlined:not(.ant-select-customize-input) .ant-select-arrow {
+  color: var(--ant-color-text);
+}
+
+.editable-string-cell:hover {
+  text-decoration: underline dotted var(--vscode-foreground);
+  text-underline-offset: 4px;
+}
+
+.ant-table-cell.value {
+  font-family: var(--ant-font-family-code);
+}
+
+.edit-field-container {
+  display: flex;
+  flex-grow: 1;
+}
+
+.edit-field-container>* {
+  flex-grow: 1;
+}

--- a/src/components/tree/components/utils.tsx
+++ b/src/components/tree/components/utils.tsx
@@ -10,14 +10,16 @@ import remarkGfm from 'remark-gfm';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../tooltip/tooltip';
 import { CDTTreeItem, CDTTreeItemResource, CDTTreeTableStringColumn } from '../types';
 
-export function classNames(...classes: (string | Record<string, boolean>)[]): string {
-    return classes.filter(c => c !== undefined).map(c => {
-        if (typeof c === 'string') {
-            return c;
+export function classNames(...classes: (string | Record<string, boolean> | undefined)[]): string {
+    return classes.map(className => {
+        if (!className) {
+            return '';
         }
-
-        return Object.entries(c).filter(([, value]) => value).map(([key]) => key);
-    }).join(' ');
+        if (typeof className === 'string') {
+            return className;
+        }
+        return Object.entries(className).filter(([, value]) => value).map(([key]) => key);
+    }).filter(className => className.length > 0).join(' ');
 }
 
 export function createHighlightedText(label?: string, highlights?: [number, number][]): React.JSX.Element {
@@ -54,7 +56,7 @@ export function createHighlightedText(label?: string, highlights?: [number, numb
 export function createLabelWithTooltip(child: React.JSX.Element, tooltip?: string): React.JSX.Element {
     const label = <div className="tree-label flex-auto flex align-items-center">
         {child}
-    </div >;
+    </div>;
 
     if (tooltip === undefined) {
         return label;

--- a/src/components/tree/tree-view.tsx
+++ b/src/components/tree/tree-view.tsx
@@ -162,6 +162,13 @@ export class CDTTreeView extends React.Component<unknown, State> {
                         }
                     }
                 }
+                edit={
+                    {
+                        onEdit: (record, value) => {
+                            this.notify(CTDTreeMessengerType.executeCommand, { data: { commandId: Commands.UPDATE_NODE_COMMAND.commandId, itemId: record.id, value } });
+                        }
+                    }
+                }
             /></div>;
     }
 

--- a/src/components/tree/types.ts
+++ b/src/components/tree/types.ts
@@ -71,21 +71,6 @@ export namespace CDTTreeItem {
 // ==== Columns ====
 
 /**
- * A column definition for a tree table.
- * This is used to define the columns that are displayed in the tree table.
- */
-export interface CDTTreeTableColumnDefinition {
-    /**
-     * The type of the column. It can be used to show different types of columns.
-     */
-    type: string;
-    /**
-     * The field that is used to get the value for this column. See {@link CDTTreeItem.columns}.
-     */
-    field: string;
-}
-
-/**
  * A string column represents a column that displays a string value.
  */
 export interface CDTTreeTableStringColumn {
@@ -101,7 +86,37 @@ export interface CDTTreeTableStringColumn {
      * The tooltip that is displayed when hovering over the string.
      */
     tooltip?: string;
+    /**
+     * If the column is editable, this property contains the data that is used to provide proper UI for it.
+     */
+    edit?: EditableData;
 }
+
+export interface EditableCellData {
+    type: string;
+}
+
+export interface EditableTextData extends EditableCellData {
+    type: 'text';
+}
+
+export interface EditableEnumData extends EditableCellData {
+    type: 'enum';
+    options: EditableEnumDataOption[];
+    value: string;
+}
+
+export interface EditableEnumDataOption {
+    value: string;
+    detail?: string;
+}
+
+export interface EditableBooleanData extends EditableCellData {
+    type: 'boolean';
+    value: '0' | '1';
+}
+
+export type EditableData = EditableTextData | EditableEnumData | EditableBooleanData;
 
 /**
  * An action column represents a column that displays multiple interactable buttons/icons.
@@ -122,6 +137,25 @@ export interface CDTTreeTableActionColumnCommand extends CommandDefinition {
 }
 
 export type CDTTreeTableColumn = CDTTreeTableStringColumn | CDTTreeTableActionColumn;
+
+export type CDTTreeTableColumnTypes =
+    | CDTTreeTableStringColumn['type']
+    | CDTTreeTableActionColumn['type'];
+
+/**
+ * A column definition for a tree table.
+ * This is used to define the columns that are displayed in the tree table.
+ */
+export interface CDTTreeTableColumnDefinition {
+    /**
+     * The type of the column. It can be used to show different types of columns.
+     */
+    type: CDTTreeTableColumnTypes;
+    /**
+     * The field that is used to get the value for this column. See {@link CDTTreeItem.columns}.
+     */
+    field: string;
+}
 
 // ==== Model ====
 

--- a/src/plugin/peripheral/nodes/base-node.ts
+++ b/src/plugin/peripheral/nodes/base-node.ts
@@ -55,8 +55,8 @@ export abstract class PeripheralBaseNode extends BaseTreeNode {
         this.pinned = false;
     }
 
-    public selected(): Thenable<boolean> {
-        return Promise.resolve(false);
+    public async selected(): Promise<boolean> {
+        return false;
     }
 
     public getId(): string {
@@ -67,8 +67,8 @@ export abstract class PeripheralBaseNode extends BaseTreeNode {
         return this.name ?? this.session?.id ?? 'unknown';
     }
 
-    public abstract performUpdate(args?: unknown): Thenable<boolean>;
-    public abstract updateData(): Thenable<boolean>;
+    public abstract performUpdate(args?: unknown): Promise<boolean>;
+    public abstract updateData(): Promise<boolean>;
 
     public abstract getChildren(): PeripheralBaseNode[] | Promise<PeripheralBaseNode[]>;
     public abstract getPeripheral(): PeripheralBaseNode | undefined;

--- a/src/plugin/peripheral/nodes/message-node.ts
+++ b/src/plugin/peripheral/nodes/message-node.ts
@@ -51,12 +51,12 @@ export class MessageNode extends PeripheralBaseNode {
         return undefined;
     }
 
-    public performUpdate(): Thenable<boolean> {
-        return Promise.resolve(false);
+    public async performUpdate(): Promise<boolean> {
+        return false;
     }
 
-    public updateData(): Thenable<boolean> {
-        return Promise.resolve(false);
+    public async updateData(): Promise<boolean> {
+        return false;
     }
 
     public getPeripheral(): PeripheralBaseNode | undefined {

--- a/src/plugin/peripheral/nodes/peripheral-cluster-node.ts
+++ b/src/plugin/peripheral/nodes/peripheral-cluster-node.ts
@@ -84,15 +84,9 @@ export class PeripheralClusterNode extends ClusterOrRegisterBaseNode {
         }
     }
 
-    public updateData(): Thenable<boolean> {
-        return new Promise((resolve, reject) => {
-            const promises = this.children.map((r) => r.updateData());
-            Promise.all(promises).then(() => {
-                resolve(true);
-            }).catch(() => {
-                reject('Failed');
-            });
-        });
+    public async updateData(): Promise<boolean> {
+        await Promise.all(this.children.map(child => child.updateData()));
+        return true;
     }
 
     public saveState(path: string): NodeSetting[] {
@@ -130,7 +124,7 @@ export class PeripheralClusterNode extends ClusterOrRegisterBaseNode {
         return this.parent.getPeripheral();
     }
 
-    public performUpdate(): Thenable<boolean> {
+    public performUpdate(): Promise<boolean> {
         throw new Error('Method not implemented.');
     }
 

--- a/src/plugin/peripheral/nodes/peripheral-node.ts
+++ b/src/plugin/peripheral/nodes/peripheral-node.ts
@@ -179,7 +179,7 @@ export class PeripheralNode extends PeripheralBaseNode {
         return this;
     }
 
-    public selected(): Thenable<boolean> {
+    public selected(): Promise<boolean> {
         return this.performUpdate();
     }
 
@@ -215,7 +215,7 @@ export class PeripheralNode extends PeripheralBaseNode {
         }
     }
 
-    public performUpdate(): Thenable<boolean> {
+    public async performUpdate(): Promise<boolean> {
         throw new Error('Method not implemented.');
     }
 

--- a/src/plugin/peripheral/tree/peripheral-session-tree.ts
+++ b/src/plugin/peripheral/tree/peripheral-session-tree.ts
@@ -257,16 +257,15 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
         }
     }
 
-    public performUpdate(): Thenable<boolean> {
-        throw new Error('Method not implemented.');
+    public async performUpdate(): Promise<boolean> {
+        return false;
     }
 
-    public updateData(): Thenable<boolean> {
+    public async updateData(): Promise<boolean> {
         if (this.loaded) {
-            const promises = this.peripherals.map((p) => p.updateData());
-            Promise.all(promises).then((_) => { this.refresh(); }, (_) => { this.refresh(); });
+            await Promise.all(this.peripherals.map(peripheral => peripheral.updateData())).finally(() => this.refresh());
         }
-        return Promise.resolve(true);
+        return true;
     }
 
     public getPeripheral(): PeripheralBaseNode {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,20 +43,29 @@ export function extractBits(value: number, offset: number, width: number): numbe
     return bvalue;
 }
 
-export function parseInteger(value: string): number | undefined {
-    if (value) {
-        value = value.toLowerCase();
-        if ((/^0b([01]+)$/i).test(value)) {
-            return parseInt(value.substring(2), 2);
-        } else if ((/^0x([0-9a-f]+)$/i).test(value)) {
-            return parseInt(value.substring(2), 16);
-        } else if ((/^[0-9]+/i).test(value)) {
-            return parseInt(value, 10);
-        } else if ((/^#[0-1]+/i).test(value)) {
-            return parseInt(value.substring(1), 2);
-        }
+export function parseInteger(value: string, { binaryLimit = Infinity, hexLimit = Infinity, decimalLimit = Infinity } = {}): number | undefined {
+    if (!value) {
+        return undefined;
     }
+    const text = value.toLowerCase();
+    const quantifier = (limit: number) => limit === Infinity ? '+' : `{1,${limit}}`;
 
+    const binRegex = new RegExp(`^0b[01]${quantifier(binaryLimit)}$`, 'i');
+    if (binRegex.test(text)) {
+        return parseInt(text.substring(2), 2);
+    }
+    const hexRegex = new RegExp(`^0x[0-9a-f]${quantifier(hexLimit)}$`, 'i');
+    if (hexRegex.test(text)) {
+        return parseInt(text.substring(2), 16);
+    }
+    const decRegex = new RegExp(`^[0-9]${quantifier(decimalLimit)}$`, 'i');
+    if (decRegex.test(text)) {
+        return parseInt(text, 10);
+    }
+    const binHashRegex = new RegExp(`^#[01]${quantifier(binaryLimit)}$`, 'i');
+    if (binHashRegex.test(text)) {
+        return parseInt(text.substring(1), 2);
+    }
     return undefined;
 }
 


### PR DESCRIPTION
- Propagate value updates back to the data provider and tracker
- Simplify column declaration and provide dedicated 'edit' property
- Provide edit renderer for text value changes

Refactor:
- Convert some utility functions to React components
- Convert thenable to promises

Closes #16

Add more edit controls for specific types

- Enumeration Dropdown for fields with enumeration values
- Boolean Checkbox edit for non-enums of width 1

Closes #22

Consider monospace font for values

Closes #45