### PR TITLE
Allow periodic updates (running and stopped CPU)

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,12 +160,12 @@
       },
       {
         "command": "peripheral-inspector.svd.periodicRefreshMode",
-        "title": "Set Periodic Refresh Mode (Workspace)",
+        "title": "Set Periodic Refresh Mode",
         "icon": "$(refresh)"
       },
       {
         "command": "peripheral-inspector.svd.periodicRefreshInterval",
-        "title": "Set Periodic Refresh Interval (Workspace)",
+        "title": "Set Periodic Refresh Interval",
         "icon": "$(calendar)"
       }
     ],
@@ -336,7 +336,7 @@
     "submenus": [
       {
         "id": "peripheral-inspector.svd.periodicRefresh",
-        "label": "Periodic Refresh",
+        "label": "Periodic Refresh  (Workspace)",
         "icon": "$(refresh)"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -161,12 +161,12 @@
       {
         "command": "peripheral-inspector.svd.periodicRefreshMode",
         "title": "Set Periodic Refresh Mode (Workspace)",
-        "icon": "$(clear-all)"
+        "icon": "$(refresh)"
       },
       {
         "command": "peripheral-inspector.svd.periodicRefreshInterval",
         "title": "Set Periodic Refresh Interval (Workspace)",
-        "icon": "$(clear-all)"
+        "icon": "$(calendar)"
       }
     ],
     "menus": {
@@ -288,18 +288,18 @@
           "group": "navigation@4"
         },
         {
-          "command": "peripheral-inspector.svd.clearIgnoredPeripherals",
-          "when": "view =~ /peripheral-inspector.peripheral-*/ && debugState == stopped && peripheral-inspector.ignoredPeripheralsLength > 0",
-          "group": "more@1"
-        },
-        {
           "command": "peripheral-inspector.svd.periodicRefreshMode",
           "when": "view =~ /peripheral-inspector.peripheral-*/",
-          "group": "more@2"
+          "group": "more@1"
         },
         {
           "command": "peripheral-inspector.svd.periodicRefreshInterval",
           "when": "view =~ /peripheral-inspector.peripheral-*/",
+          "group": "more@2"
+        },
+        {
+          "command": "peripheral-inspector.svd.clearIgnoredPeripherals",
+          "when": "view =~ /peripheral-inspector.peripheral-*/ && debugState == stopped && peripheral-inspector.ignoredPeripheralsLength > 0",
           "group": "more@3"
         }
       ],
@@ -307,17 +307,17 @@
         {
           "command": "peripheral-inspector.svd.setFormat",
           "when": "webviewId =~ /peripheral-inspector.peripheral-*/ && webviewSection == tree-item && cdtTreeItemType !== peripheral-session-node",
-          "group": "navigation"
-        },
-        {
-          "command": "peripheral-inspector.svd.ignorePeripheral",
-          "when": "webviewId =~ /peripheral-inspector.peripheral-*/ && webviewSection == tree-item && cdtTreeItemType === peripheral-node",
-          "group": "navigation"
+          "group": "navigation@0.1"
         },
         {
           "submenu": "peripheral-inspector.svd.periodicRefresh",
           "when": "webviewId =~ /peripheral-inspector.peripheral-*/",
-          "group": "navigation"
+          "group": "navigation@0.2"
+        },
+        {
+          "command": "peripheral-inspector.svd.ignorePeripheral",
+          "when": "webviewId =~ /peripheral-inspector.peripheral-*/ && webviewSection == tree-item && cdtTreeItemType === peripheral-node",
+          "group": "navigation@0.3"
         }
       ],
       "peripheral-inspector.svd.periodicRefresh": [

--- a/package.json
+++ b/package.json
@@ -157,6 +157,16 @@
         "command": "peripheral-inspector.svd.clearIgnoredPeripherals",
         "title": "Clear Ignored Peripherals (Workspace)",
         "icon": "$(clear-all)"
+      },
+      {
+        "command": "peripheral-inspector.svd.periodicRefreshMode",
+        "title": "Set Periodic Refresh Mode",
+        "icon": "$(clear-all)"
+      },
+      {
+        "command": "peripheral-inspector.svd.periodicRefreshInterval",
+        "title": "Set Periodic Refresh Interval",
+        "icon": "$(clear-all)"
       }
     ],
     "menus": {
@@ -293,9 +303,30 @@
           "command": "peripheral-inspector.svd.ignorePeripheral",
           "when": "webviewId =~ /peripheral-inspector.peripheral-*/ && webviewSection == tree-item && cdtTreeItemType === peripheral-node",
           "group": "navigation"
+        },
+        {
+          "submenu": "peripheral-inspector.svd.periodicRefresh",
+          "when": "webviewId =~ /peripheral-inspector.peripheral-*/"
+        }
+      ],
+      "peripheral-inspector.svd.periodicRefresh": [
+        {
+          "command": "peripheral-inspector.svd.periodicRefreshMode",
+          "when": "true"
+        },
+        {
+          "command": "peripheral-inspector.svd.periodicRefreshInterval",
+          "when": "true"
         }
       ]
     },
+    "submenus": [
+      {
+        "id": "peripheral-inspector.svd.periodicRefresh",
+        "label": "Periodic Refresh",
+        "icon": "$(refresh)"
+      }
+    ],
     "configuration": {
       "title": "Peripheral Inspector",
       "properties": {
@@ -338,6 +369,29 @@
             "type": "string"
           },
           "description": "List of case insensitive peripheral names to ignore"
+        },
+        "peripheral-inspector.periodicRefreshMode": {
+          "type": "string",
+          "enum": [
+            "always",
+            "while stopped",
+            "while running",
+            "off"
+          ],
+          "markdownEnumDescriptions": [
+            "Always refresh automatically after the configured `#peripheral-inspector.periodicRefreshInterval#`",
+            "Refresh automatically after the configured `#peripheral-inspector.periodicRefreshInterval#` while the CPU is stopped",
+            "Refresh automatically after the configured `#peripheral-inspector.periodicRefreshInterval#` while the CPU is running",
+            "Do not automatically refresh after the configured delay"
+          ],
+          "default": "off",
+          "markdownDescription": "Refresh Peripheral Inspectors after the configured `#peripheral-inspector.periodicRefreshInterval#`."
+        },
+        "peripheral-inspector.periodicRefreshInterval": {
+          "type": "number",
+          "default": 500,
+          "minimum": 500,
+          "markdownDescription": "Controls the delay in milliseconds after which a Peripheral Inspector is refreshed automatically. Only applies when `#peripheral-inspector.periodicRefresh#` is enabled."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -160,12 +160,12 @@
       },
       {
         "command": "peripheral-inspector.svd.periodicRefreshMode",
-        "title": "Set Periodic Refresh Mode",
+        "title": "Set Periodic Refresh Mode (Workspace)",
         "icon": "$(clear-all)"
       },
       {
         "command": "peripheral-inspector.svd.periodicRefreshInterval",
-        "title": "Set Periodic Refresh Interval",
+        "title": "Set Periodic Refresh Interval (Workspace)",
         "icon": "$(clear-all)"
       }
     ],
@@ -290,7 +290,17 @@
         {
           "command": "peripheral-inspector.svd.clearIgnoredPeripherals",
           "when": "view =~ /peripheral-inspector.peripheral-*/ && debugState == stopped && peripheral-inspector.ignoredPeripheralsLength > 0",
-          "group": "more"
+          "group": "more@1"
+        },
+        {
+          "command": "peripheral-inspector.svd.periodicRefreshMode",
+          "when": "view =~ /peripheral-inspector.peripheral-*/",
+          "group": "more@2"
+        },
+        {
+          "command": "peripheral-inspector.svd.periodicRefreshInterval",
+          "when": "view =~ /peripheral-inspector.peripheral-*/",
+          "group": "more@3"
         }
       ],
       "webview/context": [
@@ -306,17 +316,20 @@
         },
         {
           "submenu": "peripheral-inspector.svd.periodicRefresh",
-          "when": "webviewId =~ /peripheral-inspector.peripheral-*/"
+          "when": "webviewId =~ /peripheral-inspector.peripheral-*/",
+          "group": "navigation"
         }
       ],
       "peripheral-inspector.svd.periodicRefresh": [
         {
           "command": "peripheral-inspector.svd.periodicRefreshMode",
-          "when": "true"
+          "when": "true",
+          "group": "navigation@1"
         },
         {
           "command": "peripheral-inspector.svd.periodicRefreshInterval",
-          "when": "true"
+          "when": "true",
+          "group": "navigation@2"
         }
       ]
     },
@@ -327,74 +340,89 @@
         "icon": "$(refresh)"
       }
     ],
-    "configuration": {
-      "title": "Peripheral Inspector",
-      "properties": {
-        "peripheral-inspector.definitionPathConfig": {
-          "type": "string",
-          "default": "definitionPath",
-          "description": "Debug configuration key to use to get the path for the definition file"
-        },
-        "peripheral-inspector.deviceConfig": {
-          "type": "string",
-          "default": "deviceName",
-          "description": "Debug configuration key to use to get the device name"
-        },
-        "peripheral-inspector.processorConfig": {
-          "type": "string",
-          "default": "processorName",
-          "description": "Debug configuration key to use to get the processor name"
-        },
-        "peripheral-inspector.packAssetUrl": {
-          "type": "string",
-          "default": "https://pack-content.cmsis.io",
-          "description": "Base URL for CMSIS pack assets"
-        },
-        "peripheral-inspector.svdAddrGapThreshold": {
-          "type": "number",
-          "default": 16,
-          "multipleOf": 1,
-          "minimum": -1,
-          "maximum": 32,
-          "description": "If the gap between registers is less than this threshold (multiple of 8), combine into a single read from device. -1 means never combine registers and is very slow"
-        },
-        "peripheral-inspector.saveLayout": {
-          "type": "boolean",
-          "default": true,
-          "description": "Save layout of peripheral view between sessions"
-        },
-        "peripheral-inspector.ignorePeripherals": {
-          "type": "array",
-          "items": {
-            "type": "string"
+    "configuration": [
+      {
+        "title": "Peripheral Inspector"
+      },
+      {
+        "title": "Keys",
+        "properties": {
+          "peripheral-inspector.definitionPathConfig": {
+            "type": "string",
+            "default": "definitionPath",
+            "description": "Debug configuration key to use to get the path for the definition file"
           },
-          "description": "List of case insensitive peripheral names to ignore"
-        },
-        "peripheral-inspector.periodicRefreshMode": {
-          "type": "string",
-          "enum": [
-            "always",
-            "while stopped",
-            "while running",
-            "off"
-          ],
-          "markdownEnumDescriptions": [
-            "Always refresh automatically after the configured `#peripheral-inspector.periodicRefreshInterval#`",
-            "Refresh automatically after the configured `#peripheral-inspector.periodicRefreshInterval#` while the CPU is stopped",
-            "Refresh automatically after the configured `#peripheral-inspector.periodicRefreshInterval#` while the CPU is running",
-            "Do not automatically refresh after the configured delay"
-          ],
-          "default": "off",
-          "markdownDescription": "Refresh Peripheral Inspectors after the configured `#peripheral-inspector.periodicRefreshInterval#`."
-        },
-        "peripheral-inspector.periodicRefreshInterval": {
-          "type": "number",
-          "default": 500,
-          "minimum": 500,
-          "markdownDescription": "Controls the delay in milliseconds after which a Peripheral Inspector is refreshed automatically. Only applies when `#peripheral-inspector.periodicRefresh#` is enabled."
+          "peripheral-inspector.deviceConfig": {
+            "type": "string",
+            "default": "deviceName",
+            "description": "Debug configuration key to use to get the device name"
+          },
+          "peripheral-inspector.processorConfig": {
+            "type": "string",
+            "default": "processorName",
+            "description": "Debug configuration key to use to get the processor name"
+          }
+        }
+      },
+      {
+        "title": "General",
+        "properties": {
+          "peripheral-inspector.packAssetUrl": {
+            "type": "string",
+            "default": "https://pack-content.cmsis.io",
+            "description": "Base URL for CMSIS pack assets"
+          },
+          "peripheral-inspector.svdAddrGapThreshold": {
+            "type": "number",
+            "default": 16,
+            "multipleOf": 1,
+            "minimum": -1,
+            "maximum": 32,
+            "description": "If the gap between registers is less than this threshold (multiple of 8), combine into a single read from device. -1 means never combine registers and is very slow"
+          },
+          "peripheral-inspector.saveLayout": {
+            "type": "boolean",
+            "default": true,
+            "description": "Save layout of peripheral view between sessions"
+          },
+          "peripheral-inspector.ignorePeripherals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of case insensitive peripheral names to ignore"
+          }
+        }
+      },
+      {
+        "title": "Periodic Refresh",
+        "properties": {
+          "peripheral-inspector.periodicRefreshMode": {
+            "type": "string",
+            "enum": [
+              "always",
+              "while running",
+              "off"
+            ],
+            "markdownEnumDescriptions": [
+              "Always refresh automatically after the configured `#peripheral-inspector.periodicRefreshInterval#`",
+              "Refresh automatically after the configured `#peripheral-inspector.periodicRefreshInterval#` while the CPU is running",
+              "Do not automatically refresh after the configured delay"
+            ],
+            "default": "off",
+            "markdownDescription": "Refresh Peripheral Inspectors after the configured `#peripheral-inspector.periodicRefreshInterval#`.",
+            "order": 0
+          },
+          "peripheral-inspector.periodicRefreshInterval": {
+            "type": "number",
+            "default": 500,
+            "minimum": 500,
+            "markdownDescription": "Controls the delay in milliseconds after which a Peripheral Inspector is refreshed automatically. Only applies when `#peripheral-inspector.periodicRefreshMode#` is enabled.",
+            "order": 1
+          }
         }
       }
-    }
+    ]
   },
   "activationEvents": [
     "onDebug",

--- a/package.json
+++ b/package.json
@@ -336,7 +336,7 @@
     "submenus": [
       {
         "id": "peripheral-inspector.svd.periodicRefresh",
-        "label": "Periodic Refresh  (Workspace)",
+        "label": "Periodic Refresh (Workspace)",
         "icon": "$(refresh)"
       }
     ],

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -152,13 +152,13 @@ export class PeripheralCommands {
         this.config.setIgnorePeripherals();
     }
 
-    private periodicRefreshMode(context?: CTDTreeWebviewContext): void {
-        const session = context ? this.dataTracker.findSessionByPath(context.cdtTreeItemId.split(PERIPHERAL_ID_SEP)) : undefined;
-        this.config.queryPeriodicRefreshMode(session);
+    private periodicRefreshMode(_context?: CTDTreeWebviewContext): void {
+        // const session = context ? this.dataTracker.findSessionByPath(context.cdtTreeItemId.split(PERIPHERAL_ID_SEP)) : undefined;
+        this.config.queryPeriodicRefreshMode();
     }
 
-    private periodicRefreshInterval(context?: CTDTreeWebviewContext): void {
-        const session = context ? this.dataTracker.findSessionByPath(context.cdtTreeItemId.split(PERIPHERAL_ID_SEP)) : undefined;
-        this.config.queryPeriodicRefreshInterval(session);
+    private periodicRefreshInterval(_context?: CTDTreeWebviewContext): void {
+        // const session = context ? this.dataTracker.findSessionByPath(context.cdtTreeItemId.split(PERIPHERAL_ID_SEP)) : undefined;
+        this.config.queryPeriodicRefreshInterval();
     }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -153,12 +153,10 @@ export class PeripheralCommands {
     }
 
     private periodicRefreshMode(_context?: CTDTreeWebviewContext): void {
-        // const session = context ? this.dataTracker.findSessionByPath(context.cdtTreeItemId.split(PERIPHERAL_ID_SEP)) : undefined;
         this.config.queryPeriodicRefreshMode();
     }
 
     private periodicRefreshInterval(_context?: CTDTreeWebviewContext): void {
-        // const session = context ? this.dataTracker.findSessionByPath(context.cdtTreeItemId.split(PERIPHERAL_ID_SEP)) : undefined;
         this.config.queryPeriodicRefreshInterval();
     }
 }

--- a/src/common/notification.ts
+++ b/src/common/notification.ts
@@ -5,15 +5,7 @@
  * terms of the MIT License as outlined in the LICENSE File
  ********************************************************************************/
 
-export interface TreeNotificationContext {
-    /**
-     * If true or undefined, the tree will be resynced.
-     */
-    resync?: boolean;
-}
-
 export interface TreeNotification<T> {
-    context?: TreeNotificationContext;
     data: T;
 }
 

--- a/src/common/peripheral-dto.ts
+++ b/src/common/peripheral-dto.ts
@@ -202,12 +202,12 @@ export namespace PeripheralRegisterNodeDTO {
 
 export type PeripheralTreeNodeDTOs = PeripheralBaseTreeNodeDTO | PeripheralSessionNodeDTO | PeripheralNodeDTO | PeripheralRegisterNodeDTO | ClusterOrRegisterBaseNodeDTO | PeripheralClusterNodeDTO | PeripheralFieldNodeDTO;
 export namespace PeripheralTreeNodeDTOs {
-    export function getFormat(peripheralId: string | undefined, tree: Map<string, PeripheralTreeNodeDTOs>): NumberFormat {
+    export function getFormat(peripheralId: string | undefined, tree: Record<string, PeripheralTreeNodeDTOs | undefined>): NumberFormat {
         if (peripheralId === undefined) {
             return NumberFormat.Auto;
         }
 
-        const node = tree.get(peripheralId);
+        const node = tree[peripheralId];
         if (node === undefined) {
             return NumberFormat.Auto;
         }

--- a/src/components/tree/components/treetable.tsx
+++ b/src/components/tree/components/treetable.tsx
@@ -306,7 +306,13 @@ export const AntDComponentTreeTable = <T extends CDTTreeItemResource,>(props: Co
         return props.action?.onAction?.(event, command, value, record);
     }, [props.action, props.pin?.onPin]);
 
-    const renderActionCell = useCallback((column: CDTTreeTableActionColumn, record: CDTTreeItem<T>) => (<ActionCell column={column} record={record} actions={getActions(record, column)} onAction={onAction} />), [props.pin, props.action]);
+    const renderActionCell = useCallback((column: CDTTreeTableActionColumn | undefined, record: CDTTreeItem<T>) => {
+        if (!column) {
+            return undefined;
+        }
+
+        return <ActionCell column={column} record={record} actions={getActions(record, column)} onAction={onAction} />;
+    }, [props.pin, props.action]);
 
     const onSubmitEdit = useCallback((record: CDTTreeItem<T>, value: string) => {
         setEditRowKey(undefined);
@@ -328,7 +334,11 @@ export const AntDComponentTreeTable = <T extends CDTTreeItemResource,>(props: Co
 
     const isEditing = useCallback((column: CDTTreeTableStringColumn, record: CDTTreeItem<T>) => editRowKey === record.key || column.edit?.type === 'boolean' || column.edit?.type === 'enum', [editRowKey]);
 
-    const renderStringCell = useCallback((column: CDTTreeTableStringColumn, record: CDTTreeItem<T>) => {
+    const renderStringCell = useCallback((column: CDTTreeTableStringColumn | undefined, record: CDTTreeItem<T>) => {
+        if (!column) {
+            return undefined;
+        }
+
         return (<StringCell column={column} record={record} onSubmit={onSubmitEdit} onCancel={onSubmitCancel} onEdit={onEdit} editing={isEditing(column, record)} autoFocus={column.edit?.type === 'text'} />);
     }, [editRowKey]);
 
@@ -430,7 +440,8 @@ export const AntDComponentTreeTable = <T extends CDTTreeItemResource,>(props: Co
     );
 
     const onRowClick = useClickHook<HTMLElement>({
-        onSingleClick: onRowSingleClick
+        onSingleClick: onRowSingleClick,
+        delay: 10 // We don't have a double click event for now
     });
 
     // ==== Return ====

--- a/src/components/tree/components/treetable.tsx
+++ b/src/components/tree/components/treetable.tsx
@@ -421,15 +421,17 @@ export const AntDComponentTreeTable = <T extends CDTTreeItemResource,>(props: Co
     }, [autoSelectRowRef.current]);
 
     const onRowSingleClick = useCallback(
-        (record: CDTTreeItem<T>, _event: React.MouseEvent<HTMLElement>) => {
+        (_event: React.MouseEvent<HTMLElement>, record: CDTTreeItem<T>) => {
             const isExpanded = expandedRowKeys?.includes(record.id);
             handleExpand(!isExpanded, record);
             selectRow(record);
         },
-        [props.expansion]
+        [props.expansion?.expandedRowKeys]
     );
 
-    const onRowClick = (record: CDTTreeItem<T>) => useClickHook<HTMLElement>({ onSingleClick: event => onRowSingleClick(record, event) });
+    const onRowClick = useClickHook<HTMLElement>({
+        onSingleClick: onRowSingleClick
+    });
 
     // ==== Return ====
 
@@ -459,7 +461,7 @@ export const AntDComponentTreeTable = <T extends CDTTreeItemResource,>(props: Co
                     rowClassName={(record) => classNames({ 'ant-table-row-selected': record.key === selection?.key, 'ant-table-row-matched': record.matching ?? false })}
                     onRow={(record) => ({
                         record,
-                        onClick: onRowClick(record),
+                        onClick: (event) => onRowClick(event, record)
                     })}
                     expandable={{
                         expandIcon: props => <ExpandIcon {...props} />,

--- a/src/components/tree/components/utils.tsx
+++ b/src/components/tree/components/utils.tsx
@@ -182,9 +182,12 @@ export function getAncestors<T extends CDTTreeItemResource>(
     return ancestors;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ClickHookHandler<T> = (event: React.MouseEvent<T>, payload: any) => void;
+
 type UseClickHookProps<T> = {
-    onSingleClick?: MouseEventHandler<T>;
-    onDoubleClick?: MouseEventHandler<T>;
+    onSingleClick?: ClickHookHandler<T>;
+    onDoubleClick?: ClickHookHandler<T>;
     delay?: number;
 };
 
@@ -192,8 +195,9 @@ export function useClickHook<T = Element>({
     onSingleClick,
     onDoubleClick,
     delay = 250,
-}: UseClickHookProps<T>): MouseEventHandler<T> {
+}: UseClickHookProps<T>): ClickHookHandler<T> {
     const [clicks, setClicks] = useState(0);
+    const [payload, setPayload] = useState<unknown>(undefined);
     const eventRef = useRef<React.MouseEvent<T, MouseEvent> | null>(null);
 
     useEffect(() => {
@@ -203,14 +207,14 @@ export function useClickHook<T = Element>({
             // Trigger single-click after delay
             singleClickTimer = setTimeout(() => {
                 if (clicks === 1 && onSingleClick && eventRef.current) {
-                    onSingleClick(eventRef.current); // Trigger onClick
+                    onSingleClick(eventRef.current, payload); // Trigger onClick
                 }
                 setClicks(0); // Reset clicks after the delay
             }, delay);
         } else if (clicks === 2) {
             // Trigger double-click immediately
             if (onDoubleClick && eventRef.current) {
-                onDoubleClick(eventRef.current); // Trigger onDoubleClick
+                onDoubleClick(eventRef.current, payload); // Trigger onDoubleClick
             }
             setClicks(0); // Reset clicks immediately
         }
@@ -221,8 +225,9 @@ export function useClickHook<T = Element>({
         };
     }, [clicks, delay, onSingleClick, onDoubleClick]);
 
-    return (event) => {
+    return (event, payload) => {
         eventRef.current = event;
+        setPayload(payload);
         setClicks((prev) => prev + 1); // Increment the click count
     };
 }

--- a/src/components/tree/components/utils.tsx
+++ b/src/components/tree/components/utils.tsx
@@ -4,7 +4,7 @@
  * This program and the accompanying materials are made available under the
  * terms of the MIT License as outlined in the LICENSE File
  ********************************************************************************/
-import React, { MouseEventHandler, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../tooltip/tooltip';

--- a/src/components/tree/integration/tree-converter.ts
+++ b/src/components/tree/integration/tree-converter.ts
@@ -27,7 +27,11 @@ export interface TreeConverterContext<TResource extends CDTTreeItemResource = CD
      * This can be useful to access parent resources.
      * It is filled while converting the tree.
      */
-    resourceMap: Map<string, TResource>
+    assignedResources: Record<string, TResource | undefined>
+    /**
+     * A map of all items that are currently in the tree.
+     */
+    assignedItems: Record<string, CDTTreeItem<TResource> | undefined>
 }
 
 /**

--- a/src/components/tree/tree-view.tsx
+++ b/src/components/tree/tree-view.tsx
@@ -117,6 +117,10 @@ export class CDTTreeView extends React.Component<unknown, State> {
     }
 
     protected refreshPartial(items: PeripheralTreeNodeDTOs[]): void {
+        if (items.length === 0) {
+            return;
+        }
+
         this.setState(prev => {
             const context: TreeConverterContext<PeripheralTreeNodeDTOs> = {
                 expandedKeys: prev.viewModel.expandedKeys,

--- a/src/components/tree/tree-view.tsx
+++ b/src/components/tree/tree-view.tsx
@@ -20,6 +20,7 @@ import { TreeConverterContext } from './integration/tree-converter';
 import {
     CDTTreeExtensionModel,
     CDTTreeItem,
+    CDTTreePartialUpdate,
     CDTTreeViewModel,
     CTDTreeMessengerType
 } from './types';
@@ -40,7 +41,10 @@ export class CDTTreeView extends React.Component<unknown, State> {
             viewModel: {
                 items: [],
                 expandedKeys: [],
-                pinnedKeys: []
+                pinnedKeys: [],
+                references: {},
+                resources: {},
+                root: CDTTreeItem.createRoot(),
             },
         };
     }
@@ -50,11 +54,10 @@ export class CDTTreeView extends React.Component<unknown, State> {
             this.setState(prev => ({
                 ...prev, extensionModel: state,
             }));
-            this.refreshModel(state.items, {
-                resourceMap: new Map<string, PeripheralTreeNodeDTOs>(),
-                expandedKeys: PeripheralTreeNodeDTOs.extractExpandedKeys(state.items),
-                pinnedKeys: PeripheralTreeNodeDTOs.extractPinnedKeys(state.items)
-            });
+            this.refreshFull(state.items);
+        });
+        messenger.onNotification(CTDTreeMessengerType.updatePartial, (message: CDTTreePartialUpdate<PeripheralTreeNodeDTOs>) => {
+            this.refreshPartial(message.items ?? []);
         });
         messenger.onNotification(CTDTreeMessengerType.openSearch, () => {
             const elements = document.getElementsByClassName('search-overlay visible');
@@ -81,25 +84,85 @@ export class CDTTreeView extends React.Component<unknown, State> {
         messenger.sendNotification(CTDTreeMessengerType.ready, HOST_EXTENSION, undefined);
     }
 
-    protected refreshModel(items: PeripheralTreeNodeDTOs[] | undefined, context: TreeConverterContext<PeripheralTreeNodeDTOs>): void {
+    protected refreshFull(items: PeripheralTreeNodeDTOs[] | undefined): void {
+        const context: TreeConverterContext<PeripheralTreeNodeDTOs> = {
+            assignedItems: {},
+            assignedResources: {},
+            expandedKeys: [],
+            pinnedKeys: []
+        };
         const converter = new PeripheralTreeConverter();
         const toConvert = items ?? this.state.extensionModel.items ?? [];
-        const parent = CDTTreeItem.createRoot();
+        // Create a root item
+        // Allows the items to be siblings
+        const root = CDTTreeItem.createRoot();
         const convertedItems = toConvert.map(c => converter.convert(c,
             {
                 ...context,
-                parent
+                parent: root
             }
         ));
-        parent.children = convertedItems;
+        root.children = convertedItems;
 
         this.setState(prev => ({
             ...prev, viewModel: {
+                references: context.assignedItems,
+                resources: context.assignedResources,
                 expandedKeys: context.expandedKeys,
                 pinnedKeys: context.pinnedKeys,
                 items: convertedItems,
+                root
             },
         }));
+    }
+
+    protected refreshPartial(items: PeripheralTreeNodeDTOs[]): void {
+        this.setState(prev => {
+            const context: TreeConverterContext<PeripheralTreeNodeDTOs> = {
+                expandedKeys: prev.viewModel.expandedKeys,
+                pinnedKeys: prev.viewModel.pinnedKeys,
+                assignedItems: prev.viewModel.references,
+                assignedResources: prev.viewModel.resources
+            };
+            const converter = new PeripheralTreeConverter();
+
+            const convertedItems = items.map(item => {
+                let parent = prev.viewModel.root;
+                if (item.parentId) {
+                    parent = context.assignedItems[item.parentId] ?? parent;
+                }
+
+                return converter.convert(item,
+                    {
+                        ...context,
+                        parent
+                    }
+                );
+
+            });
+
+            convertedItems.forEach(item => {
+                // Replace the old item with the new one
+                const childrenToUpdate = item.parent ? item.parent.children ?? [] : prev.viewModel.items;
+                const index = childrenToUpdate.findIndex(c => c.id === item.id);
+                if (index >= 0) {
+                    childrenToUpdate[index] = item;
+                } else {
+                    childrenToUpdate.push(item);
+                }
+            });
+
+            return {
+                ...prev, viewModel: {
+                    expandedKeys: context.expandedKeys,
+                    pinnedKeys: context.pinnedKeys,
+                    references: context.assignedItems,
+                    resources: context.assignedResources,
+                    items: prev.viewModel.items,
+                    root: prev.viewModel.root
+                },
+            };
+        });
     }
 
     protected notify<TNotification extends NotificationType<unknown>>(
@@ -125,29 +188,22 @@ export class CDTTreeView extends React.Component<unknown, State> {
                     onExpand: (expanded, record) => {
                         this.setState(prev => ({ ...prev, viewModel: { ...prev.viewModel, expandedKeys: updateKeys(this.state.viewModel.expandedKeys, record.id, expanded) } }));
                         this.notify(CTDTreeMessengerType.toggleNode,
-                            { data: record.id, context: { resync: false } },
+                            { data: record.id },
                         );
                     }
                 }}
                 pin={{
                     pinnedRowKeys: this.state.viewModel.pinnedKeys,
                     onPin: (event, pinned, record) => {
-                        this.refreshModel(
-                            undefined,
-                            {
-                                resourceMap: new Map<string, PeripheralTreeNodeDTOs>(),
-                                expandedKeys: this.state.viewModel.expandedKeys,
-                                pinnedKeys: updateKeys(this.state.viewModel.pinnedKeys, record.id, pinned)
-                            }
-                        );
+                        this.setState(prev => ({ ...prev, viewModel: { ...prev.viewModel, pinnedKeys: updateKeys(this.state.viewModel.pinnedKeys, record.id, pinned) } }));
 
                         if (pinned) {
                             this.notify(CTDTreeMessengerType.executeCommand,
-                                { data: { commandId: Commands.UNPIN_COMMAND.commandId, itemId: record.id }, context: { resync: false } },
+                                { data: { commandId: Commands.UNPIN_COMMAND.commandId, itemId: record.id } },
                             );
                         } else {
                             this.notify(CTDTreeMessengerType.executeCommand,
-                                { data: { commandId: Commands.PIN_COMMAND.commandId, itemId: record.id }, context: { resync: false } },
+                                { data: { commandId: Commands.PIN_COMMAND.commandId, itemId: record.id } },
                             );
                         }
 

--- a/src/components/tree/types.ts
+++ b/src/components/tree/types.ts
@@ -184,9 +184,12 @@ export interface CDTTreeExtensionModel<TItems = unknown> {
  * It is the actual model that is used to render the tree view.
  */
 export interface CDTTreeViewModel<TItem extends CDTTreeItemResource = CDTTreeItemResource> {
+    root: CDTTreeItem<CDTTreeItemResource>;
     items: CDTTreeItem<TItem>[];
     expandedKeys: string[];
     pinnedKeys: string[];
+    references: Record<string, CDTTreeItem<TItem> | undefined>
+    resources: Record<string, TItem | undefined>
 }
 
 
@@ -212,8 +215,19 @@ export interface CDTTreeExecuteCommand {
     value?: unknown;
 }
 
+export interface CDTTreePartialUpdate<TItem = unknown> {
+    items?: TItem[];
+}
+
 export namespace CTDTreeMessengerType {
+    /**
+     * Replace the current state with the given state.
+     */
     export const updateState: NotificationType<CDTTreeExtensionModel> = { method: 'updateState' };
+    /**
+     * Update the nodes with the given nodes.
+     */
+    export const updatePartial: NotificationType<CDTTreePartialUpdate> = { method: 'updatePartial' };
     export const ready: NotificationType<void> = { method: 'ready' };
 
     export const executeCommand: NotificationType<TreeNotification<CDTTreeExecuteCommand>> = { method: 'executeCommand' };

--- a/src/debug-tracker.ts
+++ b/src/debug-tracker.ts
@@ -51,7 +51,7 @@ export class DebugTracker {
     public readonly onDidStopDebug: vscode.Event<vscode.DebugSession> = this._onDidStopDebug.event;
 
     private _onDidContinueDebug: vscode.EventEmitter<vscode.DebugSession> = new vscode.EventEmitter<vscode.DebugSession>();
-    public readonly onDidContinueDebug: vscode.Event<vscode.DebugSession> = this._onDidStopDebug.event;
+    public readonly onDidContinueDebug: vscode.Event<vscode.DebugSession> = this._onDidContinueDebug.event;
 
     public async activate(context: vscode.ExtensionContext): Promise<void> {
         const debugtracker = await this.getTracker();

--- a/src/entry-points/browser/extension.ts
+++ b/src/entry-points/browser/extension.ts
@@ -14,17 +14,19 @@ import { PeripheralDataTracker } from '../../plugin/peripheral/tree/peripheral-d
 import { SvdResolver } from '../../svd-resolver';
 import { PeripheralTreeDataProvider } from '../../plugin/peripheral/tree/peripheral-tree-data-provider';
 import { PeripheralsTreeTableWebView } from '../../plugin/peripheral/webview/peripheral-tree-webview-main';
+import { PeripheralConfigurationProvider } from '../../plugin/peripheral/tree/peripheral-configuration-provider';
 export * as api from '../../api-types';
 
 export const activate = async (context: vscode.ExtensionContext): Promise<IPeripheralInspectorAPI> => {
     const tracker = new DebugTracker();
+    const config = new PeripheralConfigurationProvider(tracker);
     const api = new PeripheralInspectorAPI();
-    const resolver = new SvdResolver(api);
+    const resolver = new SvdResolver(api, config);
 
-    const peripheralDataTracker = new PeripheralDataTracker(tracker, resolver, api, context);
+    const peripheralDataTracker = new PeripheralDataTracker(tracker, resolver, api, config, context);
     const dataProvider = new PeripheralTreeDataProvider(peripheralDataTracker, context);
     const webView = new PeripheralsTreeTableWebView(dataProvider, context);
-    const commands = new PeripheralCommands(peripheralDataTracker, webView);
+    const commands = new PeripheralCommands(peripheralDataTracker, config, webView);
 
     await tracker.activate(context);
     await commands.activate(context);

--- a/src/entry-points/desktop/extension.ts
+++ b/src/entry-points/desktop/extension.ts
@@ -14,17 +14,19 @@ import { PeripheralDataTracker } from '../../plugin/peripheral/tree/peripheral-d
 import { SvdResolver } from '../../svd-resolver';
 import { PeripheralTreeDataProvider } from '../../plugin/peripheral/tree/peripheral-tree-data-provider';
 import { PeripheralsTreeTableWebView } from '../../plugin/peripheral/webview/peripheral-tree-webview-main';
+import { PeripheralConfigurationProvider } from '../../plugin/peripheral/tree/peripheral-configuration-provider';
 export * as api from '../../api-types';
 
 export const activate = async (context: vscode.ExtensionContext): Promise<IPeripheralInspectorAPI> => {
     const tracker = new DebugTracker();
+    const config = new PeripheralConfigurationProvider(tracker);
     const api = new PeripheralInspectorAPI();
-    const resolver = new SvdResolver(api);
+    const resolver = new SvdResolver(api, config);
 
-    const peripheralDataTracker = new PeripheralDataTracker(tracker, resolver, api, context);
+    const peripheralDataTracker = new PeripheralDataTracker(tracker, resolver, api, config, context);
     const dataProvider = new PeripheralTreeDataProvider(peripheralDataTracker, context);
     const webView = new PeripheralsTreeTableWebView(dataProvider, context);
-    const commands = new PeripheralCommands(peripheralDataTracker, webView);
+    const commands = new PeripheralCommands(peripheralDataTracker, config, webView);
 
     await tracker.activate(context);
     await commands.activate(context);

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -27,7 +27,7 @@ export const DEFAULT_IGNORE_PERIPHERALS: string[] = [];
 export const CONFIG_PERIODIC_REFRESH_MODE = 'periodicRefreshMode';
 export const PERIODIC_REFRESH_MODE_CHOICES = ['always', 'while stopped', 'while running', 'off'] as const;
 export type PeriodicRefreshMode = (typeof PERIODIC_REFRESH_MODE_CHOICES)[number];
-export const DEFAULT_PERIODIC_REFRESH: PeriodicRefreshMode = 'always';
+export const DEFAULT_PERIODIC_REFRESH_MODE: PeriodicRefreshMode = 'always';
 
 export const CONFIG_PERIODIC_REFRESH_INTERVAL = 'periodicRefreshInterval';
 export const DEFAULT_PERIODIC_REFRESH_INTERVAL = 500;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -15,12 +15,22 @@ export const DEFAULT_DEVICE = 'deviceName';
 export const CONFIG_PROCESSOR = 'processorConfig';
 export const DEFAULT_PROCESSOR = 'processorName';
 export const CONFIG_ADDRGAP = 'svdAddrGapThreshold';
-export const IGNORE_PERIPHERALS = 'ignorePeripherals';
 export const DEFAULT_ADDRGAP = 16;
 export const CONFIG_ASSET_PATH = 'packAssetUrl';
 export const DEFAULT_ASSET_PATH = 'https://pack-content.cmsis.io';
 export const CONFIG_SAVE_LAYOUT = 'saveLayout';
 export const DEFAULT_SAVE_LAYOUT = true;
+export const CONFIG_IGNORE_PERIPHERALS = 'ignorePeripherals';
+export const DEFAULT_IGNORE_PERIPHERALS: string[] = [];
+
+// Periodic Refresh
+export const CONFIG_PERIODIC_REFRESH_MODE = 'periodicRefreshMode';
+export const PERIODIC_REFRESH_MODE_CHOICES = ['always', 'while stopped', 'while running', 'off'] as const;
+export type PeriodicRefreshMode = (typeof PERIODIC_REFRESH_MODE_CHOICES)[number];
+export const DEFAULT_PERIODIC_REFRESH: PeriodicRefreshMode = 'always';
+
+export const CONFIG_PERIODIC_REFRESH_INTERVAL = 'periodicRefreshInterval';
+export const DEFAULT_PERIODIC_REFRESH_INTERVAL = 500;
 
 // Commands
 export namespace Commands {
@@ -32,6 +42,8 @@ export namespace Commands {
     export const EXPORT_ALL_COMMAND_ID = `${PACKAGE_NAME}.svd.exportAll`;
     export const IGNORE_PERIPHERAL_ID = `${PACKAGE_NAME}.svd.ignorePeripheral`;
     export const CLEAR_IGNORED_PERIPHERAL_ID = `${PACKAGE_NAME}.svd.clearIgnoredPeripherals`;
+    export const PERIODIC_REFRESH_ID = `${PACKAGE_NAME}.svd.periodicRefreshMode`;
+    export const PERIODIC_REFRESH_INTERVAL_ID = `${PACKAGE_NAME}.svd.periodicRefreshInterval`;
 
     // Commands used in the UI. They are manually inserted into the DOM.
     export const UPDATE_NODE_COMMAND: CommandDefinition = {

--- a/src/plugin/peripheral/nodes/base-node.ts
+++ b/src/plugin/peripheral/nodes/base-node.ts
@@ -12,6 +12,7 @@ import { NodeSetting } from '../../../common';
 import { NumberFormat } from '../../../common/format';
 import { ClusterOrRegisterBaseNodeDTO, PERIPHERAL_ID_SEP, PeripheralBaseNodeDTO, PeripheralBaseTreeNodeDTO } from '../../../common/peripheral-dto';
 
+
 export abstract class BaseTreeNode {
     get id(): string {
         return this.getId();
@@ -47,6 +48,11 @@ export abstract class BaseTreeNode {
     }
 }
 
+export interface UpdateDataContext {
+    reason?: string;
+    changes?: PeripheralBaseNode[];
+}
+
 export abstract class PeripheralBaseNode extends BaseTreeNode {
     public format: NumberFormat;
     public pinned: boolean;
@@ -72,7 +78,7 @@ export abstract class PeripheralBaseNode extends BaseTreeNode {
     }
 
     public abstract performUpdate(args?: unknown): Promise<boolean>;
-    public abstract updateData(): Promise<boolean>;
+    public abstract updateData(context?: UpdateDataContext): Promise<boolean>;
 
     public abstract getChildren(): PeripheralBaseNode[] | Promise<PeripheralBaseNode[]>;
     public abstract getPeripheral(): PeripheralBaseNode | undefined;

--- a/src/plugin/peripheral/nodes/peripheral-field-node.ts
+++ b/src/plugin/peripheral/nodes/peripheral-field-node.ts
@@ -12,7 +12,7 @@ import { NodeSetting } from '../../../common';
 import { NumberFormat } from '../../../common/format';
 import { PeripheralFieldNodeDTO } from '../../../common/peripheral-dto';
 import { parseInteger } from '../../../utils';
-import { PeripheralBaseNode } from './base-node';
+import { PeripheralBaseNode, UpdateDataContext } from './base-node';
 import { PeripheralRegisterNode } from './peripheral-register-node';
 
 export class PeripheralFieldNode extends PeripheralBaseNode {
@@ -126,9 +126,13 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
         return false;
     }
 
-    public async updateData(): Promise<boolean> {
+    public async updateData(context?: UpdateDataContext): Promise<boolean> {
         this.previousValue = this.currentValue;
         this.currentValue = this.getCurrentValue();
+
+        if (this.previousValue !== this.currentValue) {
+            context?.changes?.push(this);
+        }
         return true;
     }
 

--- a/src/plugin/peripheral/tree/peripheral-configuration-provider.ts
+++ b/src/plugin/peripheral/tree/peripheral-configuration-provider.ts
@@ -1,0 +1,240 @@
+import * as vscode from 'vscode';
+import * as manifest from '../../../manifest';
+import { DebugTracker } from '../../../debug-tracker';
+
+export class PeripheralConfigurationProvider {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected sessionConfiguration: Map<string, { [key: string]: any }> = new Map();
+    protected sessionConfigurationEmitter: Map<string, { [key: string]: vscode.EventEmitter<unknown> }> = new Map();
+
+    constructor(tracker: DebugTracker) {
+        tracker.onWillStartSession(session => {
+            this.sessionConfiguration.set(session.id, {});
+            this.sessionConfigurationEmitter.set(session.id, {});
+        });
+        tracker.onWillStopSession(session => {
+            this.sessionConfiguration.delete(session.id);
+            const sessionConfigurationPropertyEmitters = this.sessionConfigurationEmitter.get(session.id);
+            if (sessionConfigurationPropertyEmitters) {
+                Object.keys(sessionConfigurationPropertyEmitters).forEach(key => sessionConfigurationPropertyEmitters[key].dispose());
+            }
+            this.sessionConfigurationEmitter.delete(session.id);
+        });
+    }
+
+    // Workspace Configuration
+
+    workspaceConfiguration(): vscode.WorkspaceConfiguration {
+        return vscode.workspace.getConfiguration(manifest.PACKAGE_NAME);
+    }
+
+    assetPath(): string {
+        return this.workspaceConfiguration().get<string>(manifest.CONFIG_ASSET_PATH, manifest.DEFAULT_ASSET_PATH);
+    }
+
+    onDidChangeAssetPath(callback: (newValue: string) => void): vscode.Disposable {
+        return vscode.workspace.onDidChangeConfiguration(evt => {
+            if (evt.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.CONFIG_ASSET_PATH}`)) {
+                callback(this.assetPath());
+            }
+        });
+    }
+
+    setAssetPath(assetPath: string | undefined): void {
+        this.workspaceConfiguration().update(manifest.CONFIG_ASSET_PATH, assetPath);
+    }
+
+    deviceConfig(): string {
+        return this.workspaceConfiguration().get<string>(manifest.CONFIG_DEVICE, manifest.DEFAULT_DEVICE);
+    }
+
+    onDidChangeDeviceConfig(callback: (newValue: string) => void): vscode.Disposable {
+        return vscode.workspace.onDidChangeConfiguration(evt => {
+            if (evt.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.CONFIG_DEVICE}`)) {
+                callback(this.deviceConfig());
+            }
+        });
+    }
+
+    setDeviceConfig(deviceConfig: string | undefined): void {
+        this.workspaceConfiguration().update(manifest.CONFIG_DEVICE, deviceConfig);
+    }
+
+    ignorePeripherals(): string[] {
+        return this.workspaceConfiguration().get<string[]>(manifest.CONFIG_IGNORE_PERIPHERALS, manifest.DEFAULT_IGNORE_PERIPHERALS);
+    }
+
+    onDidChangeIgnorePeripherals(callback: (newValue: string[]) => void): vscode.Disposable {
+        return vscode.workspace.onDidChangeConfiguration(evt => {
+            if (evt.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.CONFIG_IGNORE_PERIPHERALS}`)) {
+                callback(this.ignorePeripherals());
+            }
+        });
+    }
+
+    addIgnorePeripherals(...ignorePeripherals: string[]): void {
+        const ignoredPeripherals = this.ignorePeripherals();
+        this.workspaceConfiguration().update(manifest.CONFIG_IGNORE_PERIPHERALS, [...ignoredPeripherals, ...ignorePeripherals]);
+    }
+
+    setIgnorePeripherals(ignorePeripherals?: string[]): void {
+        this.workspaceConfiguration().update(manifest.CONFIG_IGNORE_PERIPHERALS, ignorePeripherals);
+    }
+
+    processorConfig(): string {
+        return this.workspaceConfiguration().get<string>(manifest.CONFIG_PROCESSOR, manifest.DEFAULT_PROCESSOR);
+    }
+
+    onDidChangeProcessorConfig(callback: (newValue: string) => void): vscode.Disposable {
+        return vscode.workspace.onDidChangeConfiguration(evt => {
+            if (evt.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.CONFIG_PROCESSOR}`)) {
+                callback(this.processorConfig());
+            }
+        });
+    }
+
+    setProcessorConfig(processorConfig: string | undefined): void {
+        this.workspaceConfiguration().update(manifest.CONFIG_PROCESSOR, processorConfig);
+    }
+
+    sdvConfig(): string {
+        return this.workspaceConfiguration().get<string>(manifest.CONFIG_SVD_PATH, manifest.DEFAULT_SVD_PATH);
+    }
+
+    onDidChangeSvdConfig(callback: (newValue: string) => void): vscode.Disposable {
+        return vscode.workspace.onDidChangeConfiguration(evt => {
+            if (evt.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.CONFIG_SVD_PATH}`)) {
+                callback(this.sdvConfig());
+            }
+        });
+    }
+
+    setSvdConfig(svdConfig: string | undefined): void {
+        this.workspaceConfiguration().update(manifest.CONFIG_SVD_PATH, svdConfig);
+    }
+
+    saveLayout(): boolean {
+        return this.workspaceConfiguration().get<boolean>(manifest.CONFIG_SAVE_LAYOUT, manifest.DEFAULT_SAVE_LAYOUT);
+    }
+
+    onDidChangeSaveLayout(callback: (newValue: boolean) => void): vscode.Disposable {
+        return vscode.workspace.onDidChangeConfiguration(evt => {
+            if (evt.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.CONFIG_SAVE_LAYOUT}`)) {
+                callback(this.saveLayout());
+            }
+        });
+    }
+
+    setSaveLayout(saveLayout: boolean | undefined): void {
+        this.workspaceConfiguration().update(manifest.CONFIG_SAVE_LAYOUT, saveLayout);
+    }
+
+    // Session Configuration
+
+    addressGapThreshold(session?: vscode.DebugSession): number {
+        return session?.configuration[manifest.CONFIG_ADDRGAP] ?? this.workspaceConfiguration().get<number>(manifest.CONFIG_ADDRGAP, manifest.DEFAULT_ADDRGAP);
+    }
+
+    deviceName(session: vscode.DebugSession): string | undefined {
+        return session.configuration[this.deviceConfig()];
+    }
+
+    processorName(session: vscode.DebugSession): string | undefined {
+        return session.configuration[this.processorConfig()];
+    }
+
+    sdvPath(session: vscode.DebugSession): string | undefined {
+        return session.configuration[this.sdvConfig()];
+    }
+
+    protected getSessionOrWorkspaceConfiguration<T>(section: string, session: vscode.DebugSession | undefined, defaultValue: T): T;
+    protected getSessionOrWorkspaceConfiguration<T>(section: string, session: vscode.DebugSession | undefined): T | undefined;
+    protected getSessionOrWorkspaceConfiguration<T>(section: string, session: vscode.DebugSession | undefined, defaultValue?: T): T | undefined {
+        // hierarchy: custom configurations > session configurations > workspace configurations
+        return this.sessionConfiguration.get(session?.id ?? 'empty')?.[section]
+            ?? session?.configuration[section]
+            ?? this.workspaceConfiguration().get<T | undefined>(section, defaultValue);
+    }
+
+    protected setSessionOrWorkspaceConfiguration<T>(section: string, session: vscode.DebugSession | undefined, value: T | undefined): void {
+        if (session) {
+            // we cannot update the session.configuration directly
+            this.sessionConfiguration.set(session.id, { ...this.sessionConfiguration.get(session.id), [section]: value });
+            this.sessionConfigurationEmitter.get(session.id)?.[section]?.fire(value);
+            return;
+        }
+        this.workspaceConfiguration().update(section, value);
+    }
+
+    protected onDidChangeSessionOrWorkspaceConfiguration<T>(section: string, session: vscode.DebugSession | undefined, callback: (newValue: T) => void, workspaceValue: () => T): vscode.Disposable {
+        const disposables: vscode.Disposable[] = [];
+        if (session) {
+            const sectionEmitters = this.sessionConfigurationEmitter.get(session.id);
+            let emitter = sectionEmitters?.[section] as vscode.EventEmitter<T>;
+            if (!emitter) {
+                emitter = new vscode.EventEmitter<T>();
+                this.sessionConfigurationEmitter.set(session.id, { ...sectionEmitters, [section]: emitter });
+            }
+            disposables.push(emitter.event(callback));
+        }
+        disposables.push(vscode.workspace.onDidChangeConfiguration(evt => {
+            if (evt.affectsConfiguration(`${manifest.PACKAGE_NAME}.${section}`)) {
+                callback(workspaceValue());
+            }
+        }));
+        return vscode.Disposable.from(...disposables);
+    }
+
+    periodicRefreshMode(session?: vscode.DebugSession): manifest.PeriodicRefreshMode {
+        return this.getSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_MODE, session, manifest.DEFAULT_PERIODIC_REFRESH);
+    }
+
+    onDidChangePeriodicRefreshMode(callback: (newValue: manifest.PeriodicRefreshMode) => void, session?: vscode.DebugSession): vscode.Disposable {
+        return this.onDidChangeSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_MODE, session, callback, () => this.periodicRefreshMode(session));
+    }
+
+    setPeriodicRefreshMode(periodicRefreshMode: manifest.PeriodicRefreshMode | undefined, session?: vscode.DebugSession): void {
+        this.setSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_MODE, session, periodicRefreshMode);
+    }
+
+    async queryPeriodicRefreshMode(session?: vscode.DebugSession): Promise<void> {
+        const context = session ? 'Session: ' : 'Workspace: ';
+        const currentValue = this.periodicRefreshMode(session);
+        const pick = await vscode.window.showQuickPick(manifest.PERIODIC_REFRESH_MODE_CHOICES, {
+            placeHolder: currentValue,
+            title: context + 'Select the periodic refresh mode'
+        });
+        if (pick) {
+            return this.setPeriodicRefreshMode(pick as manifest.PeriodicRefreshMode, session);
+        }
+    }
+
+    periodicRefreshInterval(session?: vscode.DebugSession): number {
+        return this.getSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_INTERVAL, session, manifest.DEFAULT_PERIODIC_REFRESH_INTERVAL);
+    }
+
+    onDidChangePeriodicRefreshInterval(callback: (newValue: number) => void, session?: vscode.DebugSession): vscode.Disposable {
+        return this.onDidChangeSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_INTERVAL, session, callback, () => this.periodicRefreshInterval(session));
+    }
+
+    setPeriodicRefreshInterval(periodicRefreshInterval: number | undefined, session?: vscode.DebugSession): void {
+        this.setSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_INTERVAL, session, periodicRefreshInterval);
+    }
+
+    async queryPeriodicRefreshInterval(session?: vscode.DebugSession): Promise<void> {
+        const context = session ? 'Session: ' : 'Workspace: ';
+        const currentValue = this.periodicRefreshInterval(session);
+        const input = await vscode.window.showInputBox({
+            prompt: context + 'Enter the interval in milliseconds or -1 for no refresh',
+            placeHolder: String(currentValue),
+            value: String(currentValue),
+            validateInput: value => {
+                const interval = parseInt(value);
+                return isNaN(interval) || (interval < 1 && interval !== -1) ? 'Please enter a positive integer or -1 for no refresh' : undefined;
+            }
+        });
+        if (input) {
+            return this.setPeriodicRefreshInterval(parseInt(input), session);
+        }
+    }
+}

--- a/src/plugin/peripheral/tree/peripheral-configuration-provider.ts
+++ b/src/plugin/peripheral/tree/peripheral-configuration-provider.ts
@@ -185,22 +185,23 @@ export class PeripheralConfigurationProvider {
         return vscode.Disposable.from(...disposables);
     }
 
-    periodicRefreshMode(session?: vscode.DebugSession): manifest.PeriodicRefreshMode {
+    periodicRefreshMode(session?: never): manifest.PeriodicRefreshMode {
         return this.getSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_MODE, session, manifest.DEFAULT_PERIODIC_REFRESH);
     }
 
-    onDidChangePeriodicRefreshMode(callback: (newValue: manifest.PeriodicRefreshMode) => void, session?: vscode.DebugSession): vscode.Disposable {
+    onDidChangePeriodicRefreshMode(callback: (newValue: manifest.PeriodicRefreshMode) => void, session?: never): vscode.Disposable {
         return this.onDidChangeSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_MODE, session, callback, () => this.periodicRefreshMode(session));
     }
 
-    setPeriodicRefreshMode(periodicRefreshMode: manifest.PeriodicRefreshMode | undefined, session?: vscode.DebugSession): void {
+    setPeriodicRefreshMode(periodicRefreshMode: manifest.PeriodicRefreshMode | undefined, session?: never): void {
         this.setSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_MODE, session, periodicRefreshMode);
     }
 
-    async queryPeriodicRefreshMode(session?: vscode.DebugSession): Promise<void> {
+    async queryPeriodicRefreshMode(session?: never): Promise<void> {
         const context = session ? 'Session: ' : 'Workspace: ';
         const currentValue = this.periodicRefreshMode(session);
-        const pick = await vscode.window.showQuickPick(manifest.PERIODIC_REFRESH_MODE_CHOICES, {
+        // hide 'while stopped' option for now but we want to keep the logic
+        const pick = await vscode.window.showQuickPick(manifest.PERIODIC_REFRESH_MODE_CHOICES.filter(entry => entry !== 'while stopped'), {
             placeHolder: currentValue,
             title: context + 'Select the periodic refresh mode'
         });
@@ -209,19 +210,19 @@ export class PeripheralConfigurationProvider {
         }
     }
 
-    periodicRefreshInterval(session?: vscode.DebugSession): number {
+    periodicRefreshInterval(session?: never): number {
         return this.getSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_INTERVAL, session, manifest.DEFAULT_PERIODIC_REFRESH_INTERVAL);
     }
 
-    onDidChangePeriodicRefreshInterval(callback: (newValue: number) => void, session?: vscode.DebugSession): vscode.Disposable {
+    onDidChangePeriodicRefreshInterval(callback: (newValue: number) => void, session?: never): vscode.Disposable {
         return this.onDidChangeSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_INTERVAL, session, callback, () => this.periodicRefreshInterval(session));
     }
 
-    setPeriodicRefreshInterval(periodicRefreshInterval: number | undefined, session?: vscode.DebugSession): void {
+    setPeriodicRefreshInterval(periodicRefreshInterval: number | undefined, session?: never): void {
         this.setSessionOrWorkspaceConfiguration(manifest.CONFIG_PERIODIC_REFRESH_INTERVAL, session, periodicRefreshInterval);
     }
 
-    async queryPeriodicRefreshInterval(session?: vscode.DebugSession): Promise<void> {
+    async queryPeriodicRefreshInterval(session?: never): Promise<void> {
         const context = session ? 'Session: ' : 'Workspace: ';
         const currentValue = this.periodicRefreshInterval(session);
         const input = await vscode.window.showInputBox({

--- a/src/plugin/peripheral/tree/peripheral-data-tracker.ts
+++ b/src/plugin/peripheral/tree/peripheral-data-tracker.ts
@@ -51,7 +51,7 @@ export class PeripheralDataTracker {
         tracker.onWillStartSession(session => this.onDebugSessionStarted(session));
         tracker.onWillStopSession(session => this.onDebugSessionTerminated(session));
         tracker.onDidStopDebug(session => this.onDebugStopped(session));
-        tracker.onDidContinueDebug(session => this.onDebugStopped(session));
+        tracker.onDidContinueDebug(session => this.onDebugContinued(session));
         this.init();
     }
 

--- a/src/plugin/peripheral/tree/peripheral-session-tree.ts
+++ b/src/plugin/peripheral/tree/peripheral-session-tree.ts
@@ -329,8 +329,8 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
 
         this.onSessionTerminated.forEach(disposable => disposable.dispose());
         this.onSessionTerminated = [];
-        this.onSessionTerminated.push(this.config.onDidChangePeriodicRefreshMode(() => this.updatePeriodicRefresh(), this.session));
-        this.onSessionTerminated.push(this.config.onDidChangePeriodicRefreshInterval(() => this.updatePeriodicRefresh(), this.session));
+        this.onSessionTerminated.push(this.config.onDidChangePeriodicRefreshMode(() => this.updatePeriodicRefresh()));
+        this.onSessionTerminated.push(this.config.onDidChangePeriodicRefreshInterval(() => this.updatePeriodicRefresh()));
         this.setSessionStatus(DebugSessionStatus.Started);
 
         try {
@@ -397,8 +397,8 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
             clearTimeout(this.sessionRefreshTimer);
         }
 
-        const refresh = this.config.periodicRefreshMode(this.session);
-        const interval = this.config.periodicRefreshInterval(this.session);
+        const refresh = this.config.periodicRefreshMode();
+        const interval = this.config.periodicRefreshInterval();
         if (interval <= 0 || this.sessionStatus === DebugSessionStatus.Terminated) {
             return;
         }

--- a/src/plugin/peripheral/tree/peripheral-tree-data-provider.ts
+++ b/src/plugin/peripheral/tree/peripheral-tree-data-provider.ts
@@ -27,19 +27,19 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
         this.dataTracker.onDidTerminate((event) => {
             this.onDidTerminateEvent.fire(event);
         });
-        this.dataTracker.onDidSelectionChange(() => {
-            this.onDidChangeTreeDataEvent.fire({ data: undefined });
-        });
-        this.dataTracker.onDidChange(async () => {
-            this.onDidChangeTreeDataEvent.fire({ data: undefined });
-        });
-        this.dataTracker.onDidPeripheralChange(async (event) => {
+        this.dataTracker.onDidSelectionChange((event) => {
             this.onDidChangeTreeDataEvent.fire(event);
         });
-        this.dataTracker.onDidExpand(async (event) => {
+        this.dataTracker.onDidChange((changes) => {
+            this.onDidChangeTreeDataEvent.fire({ data: changes });
+        });
+        this.dataTracker.onDidPeripheralChange((event) => {
             this.onDidChangeTreeDataEvent.fire(event);
         });
-        this.dataTracker.onDidCollapse(async (event) => {
+        this.dataTracker.onDidExpand((event) => {
+            this.onDidChangeTreeDataEvent.fire(event);
+        });
+        this.dataTracker.onDidCollapse((event) => {
             this.onDidChangeTreeDataEvent.fire(event);
         });
     }
@@ -52,11 +52,11 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
             }),
             webview.onDidExecuteCommand(async (event) => {
                 const node = this.getNodeByItemId(event.data.itemId);
-                vscode.commands.executeCommand(event.data.commandId, node, event.data.value, event.context);
+                vscode.commands.executeCommand(event.data.commandId, node, event.data.value);
             }),
             webview.onDidToggleNode((event) => {
                 const node = this.getNodeByItemId(event.data);
-                this.dataTracker.toggleNode(node, true, event.context);
+                this.dataTracker.toggleNode(node, true);
             })
         );
     }


### PR DESCRIPTION
- Add configuration for periodic refresh mode and interval
- Add commands to modify periodic refresh mode and interval
- Add context menu entries to modify periodic refresh mode and interval

Additional:
- Extract configuration provider for settings, session and ws-scoped

Fixes #36

---

**Please note** that this PR is based on https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/pull/46 and should therefore only be merged after the other PR was merged. If https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/pull/46 proves to be difficult, we may rebase this commit on the main branch.