### PR TITLE
Make the tooltip markdowns use more vertical space instead of horizontal

### DIFF
--- a/src/components/tooltip/tooltip.css
+++ b/src/components/tooltip/tooltip.css
@@ -22,7 +22,6 @@
   padding: 2px 8px;
   max-width: var(--vscode-hover-maxWidth, 500px);
   word-wrap: break-word;
-  white-space: unset;
   display: block;
   flex-direction: column;
 }

--- a/src/components/tree/integration/peripheral-tree-converter.ts
+++ b/src/components/tree/integration/peripheral-tree-converter.ts
@@ -267,8 +267,7 @@ export class PeripheralRegisterNodeConverter implements TreeResourceConverter<Pe
         const decimal = this.formatValue(resource, resource.currentValue, NumberFormat.Decimal);
         const binary = this.formatValue(resource, resource.currentValue, NumberFormat.Binary);
 
-        mds += '**Formats**\n\n';
-        mds += '| Format &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | |\n';
+        mds += '| Format | |\n';
         mds += '| :--- | :--- |\n';
         mds += `| Hex | ${hex} |\n`;
         mds += `| Decimal |  ${decimal} |\n`;
@@ -278,7 +277,6 @@ export class PeripheralRegisterNodeConverter implements TreeResourceConverter<Pe
         const children = resource.children;
         if (children.length === 0) { return mds; }
 
-        mds += '**Fields**\n\n';
         mds += '| Field | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Bit-Range | Value |\n';
         mds += '|:---|:---:|:---|:---|\n';
 
@@ -518,7 +516,7 @@ export class PeripheralFieldNodeConverter implements TreeResourceConverter<Perip
                 enumerationDescription = resource.enumeration[value].description;
             }
 
-            mds += '| Format &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | |\n';
+            mds += '| Format | |\n';
             mds += '| :--- | :--- |\n';
             mds += `| Enumeration | ${enumerationName} |\n`;
             mds += `| Hex | ${hex} |\n`;

--- a/src/components/tree/tree-view.css
+++ b/src/components/tree/tree-view.css
@@ -10,7 +10,8 @@ body {
 }
 
 .markdown {
-  line-break: anywhere;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .markdown hr {


### PR DESCRIPTION
Closes #29 

- Use vertical space instead of horizontal
- Fix word breaking

![image](https://github.com/user-attachments/assets/b98f5209-68ad-47e2-ae97-880ce0ea6aeb)
![image](https://github.com/user-attachments/assets/25f3eab3-97dc-46b9-9c69-c11cc3ff127b)
