### PR TITLE
Register range calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
           },
           "peripheral-inspector.svdAddrGapThreshold": {
             "type": "number",
-            "default": 16,
+            "default": 0,
             "multipleOf": 1,
             "minimum": -1,
             "maximum": 32,

--- a/src/addrranges.ts
+++ b/src/addrranges.ts
@@ -20,6 +20,20 @@ export class AddrRange {
     }
 }
 
+export class BitRange {
+    constructor(public offs: number, public width: number) {
+    }
+
+    /** return next address after this addr. range */
+    public mask(): number {
+        if (this.offs + this.width >= 32) { // handle uint32, could be error is > 32
+            return 0xffffffff;
+        } else {
+            return ((1 << this.width) - 1) << this.offs;
+        }
+    }
+}
+
 export class AddressRangesUtils {
     /**
      * Returns a set of address ranges that have 0 < length <= maxBytes

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -34,6 +34,7 @@ export interface PeripheralRegisterOptions {
     accessType?: AccessType;
     size?: number;
     resetValue?: number;
+    readAction?: ReadActionType;
     fields?: FieldOptions[];
 }
 
@@ -56,6 +57,7 @@ export interface FieldOptions {
     enumeration?: EnumerationMap;
     derivedFrom?: string;           // Set this if unresolved
     accessType?: AccessType;
+    readAction?: ReadActionType;
 }
 
 export interface IGetPeripheralsArguments {
@@ -79,6 +81,12 @@ export enum AccessType {
     WriteOnly = 3
 }
 
+export enum ReadActionType {
+    Clear = 1,
+    Set = 2,
+    Modify = 3,
+    ModifyExternal = 4
+}
 export interface EnumerationMap {
     [value: number]: IEnumeratedValue;
 }

--- a/src/model/peripheral/nodes/peripheral-field-node.ts
+++ b/src/model/peripheral/nodes/peripheral-field-node.ts
@@ -6,8 +6,8 @@
  ********************************************************************************/
 
 import * as vscode from 'vscode';
-import { AddrRange } from '../../../addrranges';
-import { AccessType, EnumerationMap, FieldOptions } from '../../../api-types';
+import { AddrRange, BitRange } from '../../../addrranges';
+import { AccessType, EnumerationMap, FieldOptions, ReadActionType } from '../../../api-types';
 import { NodeSetting } from '../../../common';
 import { NumberFormat } from '../../../common/format';
 import { PeripheralFieldNodeDTO } from '../../../common/peripheral-dto';
@@ -22,6 +22,7 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
     public readonly offset: number;
     public readonly width: number;
     public readonly accessType: AccessType;
+    public readonly readAction?: ReadActionType;
 
     private enumeration: EnumerationMap | undefined;
     private enumerationValues: string[] = [];
@@ -37,6 +38,7 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
         this.description = options.description;
         this.offset = options.offset;
         this.width = options.width;
+        this.readAction = options.readAction;
 
         if (!options.accessType) {
             this.accessType = parent.accessType;
@@ -159,6 +161,11 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
     public collectRanges(_a: AddrRange[]): void {
         throw new Error('Method not implemented.');
     }
+
+    public collectBitRanges(addrs: BitRange[]): void {
+        addrs.push(new BitRange(this.offset, this.width));
+    }
+
 
     public resolveDeferedEnums(enumTypeValuesMap: { [key: string]: EnumerationMap; }) {
         if (this.options.derivedFrom) {

--- a/src/svd-parser.ts
+++ b/src/svd-parser.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { parseStringPromise } from 'xml2js';
-import { AccessType, ClusterOptions, EnumerationMap, FieldOptions, PeripheralOptions, PeripheralRegisterOptions, PeripheralsConfiguration } from './api-types';
+import { AccessType, ClusterOptions, EnumerationMap, FieldOptions, PeripheralOptions, PeripheralRegisterOptions, PeripheralsConfiguration, ReadActionType } from './api-types';
 import { EnumeratedValue } from './enumerated-value';
 import { parseDimIndex, parseInteger } from './utils';
 
@@ -27,6 +27,21 @@ const accessTypeFromString = (type: string): AccessType => {
             return AccessType.ReadOnly;
         }
     }
+};
+
+const readActionFromString = (type: string): ReadActionType | undefined => {
+    switch (type) {
+        case 'clear':
+            return ReadActionType.Clear;
+        case 'se':
+            return ReadActionType.Set;
+        case 'modify':
+            return ReadActionType.Modify;
+        case 'modifyExternal':
+            return ReadActionType.ModifyExternal;
+    }
+
+    return undefined;
 };
 
 export interface Peripheral {
@@ -203,6 +218,9 @@ export class SVDParser {
             if (f.access) {
                 baseOptions.accessType = accessTypeFromString(f.access[0]);
             }
+            if (f.readAction) {
+                baseOptions.readAction = readActionFromString(f.readAction[0]);
+            }
 
             if (f.dim) {
                 const count = parseInteger(f.dim[0]);
@@ -284,6 +302,9 @@ export class SVDParser {
             }
             if (r.resetValue) {
                 baseOptions.resetValue = parseInteger(r.resetValue[0]) ?? 0;
+            }
+            if (r.readAction) {
+                baseOptions.readAction = readActionFromString(r.readAction[0]);
             }
 
             if (r.dim) {

--- a/src/svd-parser.ts
+++ b/src/svd-parser.ts
@@ -33,7 +33,7 @@ const readActionFromString = (type: string): ReadActionType | undefined => {
     switch (type) {
         case 'clear':
             return ReadActionType.Clear;
-        case 'se':
+        case 'set':
             return ReadActionType.Set;
         case 'modify':
             return ReadActionType.Modify;


### PR DESCRIPTION
## Changes
- Set the default value of `svdAddrGapThreshold` to 0 to prevent debuggers from reading over non-existent memory locations
- Evaluated the <readAction> tag to exclude corresponding registers or fields from the overall READ.

Performance should generally remain unchanged even with increased reads, but debuggers will no longer encounter errors from non-existent memory.

See issue: https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/60
