### PR TITLE
Correctly handle debug-tracker-vscode terminated event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fixes
 
-- [#16](https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/60): Rework peripheral read strategy and peripheral-inspector.svdAddrGapThreshold
+- [#16](https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/60): Rework peripheral read strategy and peripheral-inspector.svdAddrGapThreshold ([Thorsten de Buhr](https://github.com/thorstendb-ARM/))
+- [#63](https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/63): Peripheral Inspector does not clear on disconnect if using debug-tracker-vscode ([Jens Reinecke](https://github.com/jreineckearm))
 
 ## [v1.7.0] - 2025-03-31
 

--- a/src/debug-tracker.ts
+++ b/src/debug-tracker.ts
@@ -66,8 +66,11 @@ export class DebugTracker {
                         if (event.event === DebugSessionStatus.Initializing && event.session) {
                             this.handleOnWillStartSession(event.session);
                         }
-                        if (event.event === DebugSessionStatus.Terminated && event.sessionId) {
-                            this.handleOnWillStopSession(event.sessionId);
+                        if (event.event === DebugSessionStatus.Terminated) {
+                            const terminatedEventInfo = event.session ?? event.sessionId;
+                            if (terminatedEventInfo) {
+                                this.handleOnWillStopSession(terminatedEventInfo);
+                            }
                         }
                         if (event.event === DebugSessionStatus.Stopped && event.session) {
                             this.handleOnDidStopDebug(event.session);

--- a/src/debug-tracker.ts
+++ b/src/debug-tracker.ts
@@ -12,6 +12,7 @@ const DEBUG_TRACKER_EXTENSION = 'mcu-debug.debug-tracker-vscode';
 interface IDebuggerTrackerEvent {
     event: DebugSessionStatus;
     session?: vscode.DebugSession;
+    sessionId?: string;
 }
 
 interface IDebuggerTrackerSubscribeArgBodyV1 {
@@ -44,8 +45,8 @@ export class DebugTracker {
     private _onWillStartSession: vscode.EventEmitter<vscode.DebugSession> = new vscode.EventEmitter<vscode.DebugSession>();
     public readonly onWillStartSession: vscode.Event<vscode.DebugSession> = this._onWillStartSession.event;
 
-    private _onWillStopSession: vscode.EventEmitter<vscode.DebugSession> = new vscode.EventEmitter<vscode.DebugSession>();
-    public readonly onWillStopSession: vscode.Event<vscode.DebugSession> = this._onWillStopSession.event;
+    private _onWillStopSession: vscode.EventEmitter<string | vscode.DebugSession> = new vscode.EventEmitter<string | vscode.DebugSession>();
+    public readonly onWillStopSession: vscode.Event<string | vscode.DebugSession> = this._onWillStopSession.event;
 
     private _onDidStopDebug: vscode.EventEmitter<vscode.DebugSession> = new vscode.EventEmitter<vscode.DebugSession>();
     public readonly onDidStopDebug: vscode.Event<vscode.DebugSession> = this._onDidStopDebug.event;
@@ -65,8 +66,8 @@ export class DebugTracker {
                         if (event.event === DebugSessionStatus.Initializing && event.session) {
                             this.handleOnWillStartSession(event.session);
                         }
-                        if (event.event === DebugSessionStatus.Terminated && event.session) {
-                            this.handleOnWillStopSession(event.session);
+                        if (event.event === DebugSessionStatus.Terminated && event.sessionId) {
+                            this.handleOnWillStopSession(event.sessionId);
                         }
                         if (event.event === DebugSessionStatus.Stopped && event.session) {
                             this.handleOnDidStopDebug(event.session);
@@ -104,7 +105,7 @@ export class DebugTracker {
         this._onWillStartSession.fire(session);
     }
 
-    private handleOnWillStopSession(session: vscode.DebugSession): void {
+    private handleOnWillStopSession(session: string | vscode.DebugSession): void {
         this._onWillStopSession.fire(session);
     }
 

--- a/src/model/peripheral/tree/peripheral-configuration-provider.ts
+++ b/src/model/peripheral/tree/peripheral-configuration-provider.ts
@@ -13,12 +13,13 @@ export class PeripheralConfigurationProvider {
             this.sessionConfigurationEmitter.set(session.id, {});
         });
         tracker.onWillStopSession(session => {
-            this.sessionConfiguration.delete(session.id);
-            const sessionConfigurationPropertyEmitters = this.sessionConfigurationEmitter.get(session.id);
+            const sessionId = typeof session === 'string' ? session : session.id;
+            this.sessionConfiguration.delete(sessionId);
+            const sessionConfigurationPropertyEmitters = this.sessionConfigurationEmitter.get(sessionId);
             if (sessionConfigurationPropertyEmitters) {
                 Object.keys(sessionConfigurationPropertyEmitters).forEach(key => sessionConfigurationPropertyEmitters[key].dispose());
             }
-            this.sessionConfigurationEmitter.delete(session.id);
+            this.sessionConfigurationEmitter.delete(sessionId);
         });
     }
 

--- a/src/model/peripheral/tree/peripheral-data-tracker.ts
+++ b/src/model/peripheral/tree/peripheral-data-tracker.ts
@@ -334,15 +334,18 @@ export class PeripheralDataTracker {
         this.refreshContext();
     }
 
-    protected onDebugSessionTerminated(session: vscode.DebugSession): void {
-        if (!this.sessionPeripherals.get(session.id)) {
+    protected onDebugSessionTerminated(session: string | vscode.DebugSession): void {
+        const isSessionId = typeof session === 'string';
+        const sessionId = isSessionId ? session : session.id;
+        if (!this.sessionPeripherals.get(sessionId)) {
             return;
         }
-        const regs = this.sessionPeripherals.get(session.id);
+        const regs = this.sessionPeripherals.get(sessionId);
 
         if (regs) {
-            this.oldState.set(session.name, regs.expanded);
-            this.sessionPeripherals.delete(session.id);
+            const sessionName = isSessionId ? regs.name : session.name;
+            this.oldState.set(sessionName, regs.expanded);
+            this.sessionPeripherals.delete(sessionId);
             regs.sessionTerminated(this.context);
             this.onDidTerminateEvent.fire({
                 data: regs,


### PR DESCRIPTION
Closes #63 

Root cause is that the debug-tracker-vscode extension only sends a session ID but not the full session information as the original events do. The Peripheral Inspector doesn't handle that correctly while it should support events tracked by this extension. It is used by a couple of debug adapters out there.

This PR changes the terminated event handling to deal with just the session ID coming in.