### PR TITLE
Fix debug tracker integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.8.1] - 2025-07-09
+
+### Bug Fixes
+
+- [#68](https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/68): No peripheral updates on 'stopped' event if using debug-tracker-vscode. ([Jens Reinecke](https://github.com/jreineckearm))
+
 ## [v1.8.0] - 2025-05-26
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peripheral-inspector",
   "displayName": "Peripheral Inspector",
   "description": "Standalone Peripheral Inspector extension extracted from cortex-debug",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "publisher": "eclipse-cdt",
   "author": "marus25",
   "contributors": [

--- a/src/debug-tracker.ts
+++ b/src/debug-tracker.ts
@@ -48,11 +48,11 @@ export class DebugTracker {
     private _onWillStopSession: vscode.EventEmitter<string | vscode.DebugSession> = new vscode.EventEmitter<string | vscode.DebugSession>();
     public readonly onWillStopSession: vscode.Event<string | vscode.DebugSession> = this._onWillStopSession.event;
 
-    private _onDidStopDebug: vscode.EventEmitter<vscode.DebugSession> = new vscode.EventEmitter<vscode.DebugSession>();
-    public readonly onDidStopDebug: vscode.Event<vscode.DebugSession> = this._onDidStopDebug.event;
+    private _onDidStopDebug: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
+    public readonly onDidStopDebug: vscode.Event<string> = this._onDidStopDebug.event;
 
-    private _onDidContinueDebug: vscode.EventEmitter<vscode.DebugSession> = new vscode.EventEmitter<vscode.DebugSession>();
-    public readonly onDidContinueDebug: vscode.Event<vscode.DebugSession> = this._onDidContinueDebug.event;
+    private _onDidContinueDebug: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
+    public readonly onDidContinueDebug: vscode.Event<string> = this._onDidContinueDebug.event;
 
     public async activate(context: vscode.ExtensionContext): Promise<void> {
         const debugtracker = await this.getTracker();
@@ -63,20 +63,18 @@ export class DebugTracker {
                 body: {
                     debuggers: '*',
                     handler: async event => {
+                        const sessionId = event.session?.id ?? event.sessionId;
                         if (event.event === DebugSessionStatus.Initializing && event.session) {
                             this.handleOnWillStartSession(event.session);
                         }
-                        if (event.event === DebugSessionStatus.Terminated) {
-                            const terminatedEventInfo = event.session ?? event.sessionId;
-                            if (terminatedEventInfo) {
-                                this.handleOnWillStopSession(terminatedEventInfo);
-                            }
+                        if (event.event === DebugSessionStatus.Terminated && sessionId) {
+                            this.handleOnWillStopSession(sessionId);
                         }
-                        if (event.event === DebugSessionStatus.Stopped && event.session) {
-                            this.handleOnDidStopDebug(event.session);
+                        if (event.event === DebugSessionStatus.Stopped && sessionId) {
+                            this.handleOnDidStopDebug(sessionId);
                         }
-                        if (event.event === DebugSessionStatus.Running && event.session) {
-                            this.handleOnDidContinueDebug(event.session);
+                        if (event.event === DebugSessionStatus.Running && sessionId) {
+                            this.handleOnDidContinueDebug(sessionId);
                         }
                     }
                 }
@@ -89,10 +87,10 @@ export class DebugTracker {
                     onWillStopSession: () => this.handleOnWillStopSession(session),
                     onDidSendMessage: message => {
                         if (message.type === 'event' && message.event === 'stopped') {
-                            this.handleOnDidStopDebug(session);
+                            this.handleOnDidStopDebug(session.id);
                         }
                         if (message.type === 'event' && message.event === 'continued') {
-                            this.handleOnDidContinueDebug(session);
+                            this.handleOnDidContinueDebug(session.id);
                         }
                     }
                 };
@@ -112,11 +110,11 @@ export class DebugTracker {
         this._onWillStopSession.fire(session);
     }
 
-    private handleOnDidStopDebug(session: vscode.DebugSession): void {
+    private handleOnDidStopDebug(session: string): void {
         this._onDidStopDebug.fire(session);
     }
 
-    private handleOnDidContinueDebug(session: vscode.DebugSession): void {
+    private handleOnDidContinueDebug(session: string): void {
         this._onDidContinueDebug.fire(session);
     }
 

--- a/src/model/peripheral/tree/peripheral-data-tracker.ts
+++ b/src/model/peripheral/tree/peripheral-data-tracker.ts
@@ -356,12 +356,12 @@ export class PeripheralDataTracker {
         this.refreshContext();
     }
 
-    protected onDebugStopped(session: vscode.DebugSession): void {
-        this.sessionPeripherals.get(session.id)?.debugStopped(this.context);
+    protected onDebugStopped(sessionId: string): void {
+        this.sessionPeripherals.get(sessionId)?.debugStopped(this.context);
     }
 
-    protected onDebugContinued(session: vscode.DebugSession): void {
-        this.sessionPeripherals.get(session.id)?.debugContinued(this.context);
+    protected onDebugContinued(sessionId: string): void {
+        this.sessionPeripherals.get(sessionId)?.debugContinued(this.context);
     }
 
     protected refreshContext(): void {


### PR DESCRIPTION
Fixes #68 

* Only pass session ID to debug continue/stop event handlers.
* Correctly determine session ID for the two events for debug-tracker-vscode integration.
* v1.8.1 and changelog for patch release.