### PR TITLE
Implement backend tree search and partial lazy loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@vscode/codicons": "0.0.45",
-    "@eclipse-cdt-cloud/vscode-ui-components": "0.0.1",
+    "@eclipse-cdt-cloud/vscode-ui-components": "^0.1.0",
     "jszip": "^3.10.1",
     "node-fetch": "^3.3.2",
     "react": "^18.2.0",

--- a/src/model/peripheral/tree/peripheral-data-tracker.ts
+++ b/src/model/peripheral/tree/peripheral-data-tracker.ts
@@ -374,35 +374,20 @@ export class PeripheralDataTracker {
             return [];
         }
 
-        const visited = new Set<string>();
         const matches: PeripheralBaseNode[] = [];
-
         const roots = Array.from(this.sessionPeripherals.values());
         const stack: PeripheralBaseNode[] = [...roots];
 
         while (stack.length > 0) {
             const node = stack.pop();
-
             if (!node) {
                 continue;
             }
-
-            const id = node.getId();
-
-            if (visited.has(id)) {
-                continue;
-            }
-
-            visited.add(id);
-
             const name = (node.name ?? '').toLowerCase();
-
             const exactOrPrefix =
                 name === normalized ||
                 name.startsWith(normalized);
-
             const substringMatch = name.includes(normalized);
-
             if (exactOrPrefix || substringMatch) {
                 matches.push(node);
             }

--- a/src/model/peripheral/tree/peripheral-data-tracker.ts
+++ b/src/model/peripheral/tree/peripheral-data-tracker.ts
@@ -367,4 +367,61 @@ export class PeripheralDataTracker {
     protected refreshContext(): void {
         vscode.commands.executeCommand('setContext', `${PeripheralTreeDataProvider.viewName}.hasData`, this.sessionPeripherals.size > 0);
     }
+
+    public async findNodesByText(query: string): Promise<PeripheralBaseNode[]> {
+        const normalized = (query ?? '').trim().toLowerCase();
+        if (!normalized) {
+            return [];
+        }
+
+        const allowGlobalSubstring = normalized.length > 2;
+
+        const visited = new Set<string>();
+        const fieldMatches: PeripheralBaseNode[] = [];
+        const registerMatches: PeripheralBaseNode[] = [];
+        const otherMatches: PeripheralBaseNode[] = [];
+
+        const roots = Array.from(this.sessionPeripherals.values());
+        const stack: PeripheralBaseNode[] = [...roots];
+
+        while (stack.length > 0) {
+            const node = stack.pop();
+            if (!node) continue;
+
+            const id = node.getId();
+            if (visited.has(id)) continue;
+            visited.add(id);
+
+            const name = (node.name ?? '').toLowerCase();
+            const isField = node instanceof PeripheralFieldNode;
+            const isRegister = node instanceof PeripheralRegisterNode;
+
+            const exactOrPrefix =
+                name === normalized ||
+                name.startsWith(normalized);
+
+            const substringAllowed =
+                allowGlobalSubstring || isField;
+
+            const substringMatch =
+                substringAllowed && name.includes(normalized);
+
+            if (exactOrPrefix || substringMatch) {
+                if (isField) {
+                    fieldMatches.push(node);
+                } else if (isRegister) {
+                    registerMatches.push(node);
+                } else {
+                    otherMatches.push(node);
+                }
+            }
+
+            const children = await node.getChildren();
+            for (const child of children) {
+                stack.push(child);
+            }
+        }
+
+        return [...fieldMatches, ...registerMatches, ...otherMatches];
+    }
 }

--- a/src/model/peripheral/tree/peripheral-data-tracker.ts
+++ b/src/model/peripheral/tree/peripheral-data-tracker.ts
@@ -374,46 +374,37 @@ export class PeripheralDataTracker {
             return [];
         }
 
-        const allowGlobalSubstring = normalized.length > 2;
-
         const visited = new Set<string>();
-        const fieldMatches: PeripheralBaseNode[] = [];
-        const registerMatches: PeripheralBaseNode[] = [];
-        const otherMatches: PeripheralBaseNode[] = [];
+        const matches: PeripheralBaseNode[] = [];
 
         const roots = Array.from(this.sessionPeripherals.values());
         const stack: PeripheralBaseNode[] = [...roots];
 
         while (stack.length > 0) {
             const node = stack.pop();
-            if (!node) continue;
+
+            if (!node) {
+                continue;
+            }
 
             const id = node.getId();
-            if (visited.has(id)) continue;
+
+            if (visited.has(id)) {
+                continue;
+            }
+
             visited.add(id);
 
             const name = (node.name ?? '').toLowerCase();
-            const isField = node instanceof PeripheralFieldNode;
-            const isRegister = node instanceof PeripheralRegisterNode;
 
             const exactOrPrefix =
                 name === normalized ||
                 name.startsWith(normalized);
 
-            const substringAllowed =
-                allowGlobalSubstring || isField;
-
-            const substringMatch =
-                substringAllowed && name.includes(normalized);
+            const substringMatch = name.includes(normalized);
 
             if (exactOrPrefix || substringMatch) {
-                if (isField) {
-                    fieldMatches.push(node);
-                } else if (isRegister) {
-                    registerMatches.push(node);
-                } else {
-                    otherMatches.push(node);
-                }
+                matches.push(node);
             }
 
             const children = await node.getChildren();
@@ -422,6 +413,6 @@ export class PeripheralDataTracker {
             }
         }
 
-        return [...fieldMatches, ...registerMatches, ...otherMatches];
+        return matches;
     }
 }

--- a/src/views/peripheral/peripheral-data-provider.ts
+++ b/src/views/peripheral/peripheral-data-provider.ts
@@ -81,7 +81,12 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
     }
 
     async getSerializedRoots(): Promise<PeripheralBaseNodeDTO[]> {
-        const children = await this.getChildren() ?? [];
+        let children = await this.getChildren() ?? [];
+
+        const searchState = this.searchState;
+        if (searchState) {
+            children = children.filter(child => this.shouldIncludeInSearchTree(child, searchState));
+        }
 
         return Promise.all(children.map(c => this.getSerializedData(c)));
     }
@@ -256,5 +261,14 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
         return item;
     }
 
+    private shouldIncludeInSearchTree(
+        node: PeripheralBaseNode,
+        searchState: SearchState
+    ): boolean {
+        return (searchState.includeIds.has(
+            node.getId()) ||
+            this.isDescendantOfDirectMatch(node, searchState.directMatchIds)
+        );
+    }
 }
 

--- a/src/views/peripheral/peripheral-data-provider.ts
+++ b/src/views/peripheral/peripheral-data-provider.ts
@@ -14,6 +14,12 @@ import * as manifest from '../../manifest';
 import { PeripheralBaseNode, PeripheralRegisterNode } from '../../model/peripheral/nodes';
 import { PeripheralDataTracker } from '../../model/peripheral/tree/peripheral-data-tracker';
 
+type SearchState = {
+    includeIds: Set<string>;
+    directMatchIds: Set<string>;
+    defaultExpandedIds: Set<string>;
+};
+
 export class PeripheralTreeDataProvider implements CDTTreeDataProvider<PeripheralBaseNode, PeripheralBaseNodeDTO> {
     public static viewName = `${manifest.PACKAGE_NAME}.svd`;
 
@@ -22,8 +28,7 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
     protected onDidChangeTreeDataEvent = new vscode.EventEmitter<TreeNotification<PeripheralBaseNode | PeripheralBaseNode[] | undefined>>();
     readonly onDidChangeTreeData = this.onDidChangeTreeDataEvent.event;
 
-    private includeIds?: Set<string>;
-    private defaultExpandedIds?: Set<string>;
+    private searchState?: SearchState;
     private searchSequence = 0;
 
     constructor(protected readonly dataTracker: PeripheralDataTracker, protected context: vscode.ExtensionContext) {
@@ -61,7 +66,7 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
                 const node = this.getNodeByItemId(event.data);
                 this.dataTracker.toggleNode(node, true);
             }),
-            webview.onDidSearchChanged((event) => {
+            webview.onDidSearchChange((event) => {
                 const text = event.data?.text ?? '';
                 this.handleSearchText(text);
             })
@@ -84,74 +89,11 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
     async getSerializedData(element: PeripheralBaseNode): Promise<PeripheralBaseNodeDTO> {
         const item = await element.serialize();
 
-        // ===== SEARCH MODE =====
-        if (this.includeIds) {
-            const includeIds = this.includeIds;
-
-            if (!includeIds.has(element.getId())) {
-                return item;
-            }
-
-            const children = (await this.getChildren(element)) ?? [];
-
-            if (element instanceof PeripheralRegisterNode) {
-                item.expanded =
-                    element.expanded ||
-                    this.defaultExpandedIds?.has(element.getId()) === true;
-
-                if (children.length > 0) {
-                    item.children = await Promise.all(
-                        children.map(child => this.getSerializedData(child))
-                    );
-                }
-
-                return item;
-            }
-
-            const visibleChildren = children.filter(child =>
-                includeIds.has(child.getId())
-            );
-
-            if (visibleChildren.length > 0) {
-                item.expanded =
-                    element.expanded ||
-                    this.defaultExpandedIds?.has(element.getId()) === true;
-
-                item.children = await Promise.all(
-                    visibleChildren.map(child => this.getSerializedData(child))
-                );
-            }
-
-            return item;
+        if (!this.searchState) {
+            return this.serializeLazyNode(element, item);
         }
 
-        // ===== NORMAL LAZY MODE =====
-
-        if (element instanceof PeripheralRegisterNode) {
-            const children = (await this.getChildren(element)) ?? [];
-
-            if (children.length > 0) {
-                item.children = await Promise.all(
-                    children.map(child => this.getSerializedData(child))
-                );
-            }
-
-            return item;
-        }
-
-        if (!element.expanded) {
-            return item;
-        }
-
-        const children = (await this.getChildren(element)) ?? [];
-
-        if (children.length > 0) {
-            item.children = await Promise.all(
-                children.map(child => this.getSerializedData(child))
-            );
-        }
-
-        return item;
+        return this.serializeSearchNode(element, item);
     }
 
     getChildren(element?: PeripheralBaseNode): vscode.ProviderResult<PeripheralBaseNode[]> {
@@ -173,42 +115,145 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
 
     private handleSearchText(text: string): void {
         const sequence = ++this.searchSequence;
-        const normalized = (text ?? '').trim();
+        const normalized = text.trim();
 
         if (!normalized) {
-            this.searchSequence++;
-            this.includeIds = undefined;
-            this.defaultExpandedIds = undefined;
-            this.onDidChangeTreeDataEvent.fire({ data: undefined });
+            this.clearSearchState();
             return;
         }
 
-        void (async () => {
-            const matches = await this.dataTracker.findNodesByText(normalized);
+        void this.updateSearchState(normalized, sequence);
+    }
 
-            if (sequence !== this.searchSequence) {
-                return; // Ignore stale results
+    private clearSearchState(): void {
+        this.searchSequence++;
+        this.searchState = undefined;
+        this.onDidChangeTreeDataEvent.fire({ data: undefined });
+    }
+
+    private async updateSearchState(query: string, sequence: number): Promise<void> {
+        const matches = await this.dataTracker.findNodesByText(query);
+
+        if (sequence !== this.searchSequence) {
+            return;
+        }
+
+        this.searchState = this.buildSearchState(matches);
+        this.onDidChangeTreeDataEvent.fire({ data: undefined });
+    }
+
+    private buildSearchState(matches: PeripheralBaseNode[]): SearchState {
+        const includeIds = new Set<string>();
+        const directMatchIds = new Set<string>();
+        const defaultExpandedIds = new Set<string>();
+
+        for (const node of matches) {
+            const nodeId = node.getId();
+            directMatchIds.add(nodeId);
+            includeIds.add(nodeId);
+
+            let parent = node.getParent?.() as PeripheralBaseNode | undefined;
+            while (parent) {
+                includeIds.add(parent.getId());
+                defaultExpandedIds.add(parent.getId());
+                parent = parent.getParent?.() as PeripheralBaseNode | undefined;
+            }
+        }
+
+        return { includeIds, directMatchIds, defaultExpandedIds };
+    }
+
+    private async serializeSearchNode(
+        element: PeripheralBaseNode,
+        item: PeripheralBaseNodeDTO
+    ): Promise<PeripheralBaseNodeDTO> {
+        const searchState = this.searchState;
+        if (!searchState) {
+            return this.serializeLazyNode(element, item);
+        }
+
+        const isIncluded = searchState.includeIds.has(element.getId());
+        const isDirectMatch = searchState.directMatchIds.has(element.getId());
+        const isDescendantOfDirectMatch = this.isDescendantOfDirectMatch(element, searchState.directMatchIds);
+
+        if (!isIncluded && !isDescendantOfDirectMatch) {
+            return item;
+        }
+
+        if (isDirectMatch || isDescendantOfDirectMatch) {
+            return this.serializeLazyNode(element, item);
+        }
+
+        return this.serializeAncestorNode(element, item, searchState);
+    }
+
+    private isDescendantOfDirectMatch(
+        node: PeripheralBaseNode,
+        directMatchIds: Set<string>
+    ): boolean {
+        let parent = node.getParent?.() as PeripheralBaseNode | undefined;
+
+        while (parent) {
+            if (directMatchIds.has(parent.getId())) {
+                return true;
             }
 
-            const include = new Set<string>();
-            const expand = new Set<string>();
+            parent = parent.getParent?.() as PeripheralBaseNode | undefined;
+        }
 
-            for (const node of matches) {
-                include.add(node.getId());
+        return false;
+    }
 
-                let parent = node.getParent?.() as PeripheralBaseNode | undefined;
-                while (parent) {
-                    include.add(parent.getId());
-                    expand.add(parent.getId());
-                    parent = parent.getParent?.() as PeripheralBaseNode | undefined;
-                }
-            }
+    private async serializeAncestorNode(
+        element: PeripheralBaseNode,
+        item: PeripheralBaseNodeDTO,
+        searchState: SearchState
+    ): Promise<PeripheralBaseNodeDTO> {
+        const children = (await this.getChildren(element)) ?? [];
 
-            this.includeIds = include;
-            this.defaultExpandedIds = expand;
+        item.expanded =
+            element.expanded ||
+            searchState.defaultExpandedIds.has(element.getId());
 
-            this.onDidChangeTreeDataEvent.fire({ data: undefined });
-        })();
+        const visibleChildren = children.filter(child => searchState.includeIds.has(child.getId()));
+
+        if (visibleChildren.length > 0) {
+            item.children = await Promise.all(
+                visibleChildren.map(child => this.getSerializedData(child))
+            );
+        }
+
+        return item;
+    }
+
+    private async serializeLazyNode(
+        element: PeripheralBaseNode,
+        item: PeripheralBaseNodeDTO
+    ): Promise<PeripheralBaseNodeDTO> {
+        if (element instanceof PeripheralRegisterNode) {
+            return this.serializeAllChildren(element, item);
+        }
+
+        if (!element.expanded) {
+            return item;
+        }
+
+        return this.serializeAllChildren(element, item);
+    }
+
+    private async serializeAllChildren(
+        element: PeripheralBaseNode,
+        item: PeripheralBaseNodeDTO
+    ): Promise<PeripheralBaseNodeDTO> {
+        const children = (await this.getChildren(element)) ?? [];
+
+        if (children.length > 0) {
+            item.children = await Promise.all(
+                children.map(child => this.getSerializedData(child))
+            );
+        }
+
+        return item;
     }
 
 }

--- a/src/views/peripheral/peripheral-data-provider.ts
+++ b/src/views/peripheral/peripheral-data-provider.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode';
 import { TreeNotification, TreeTerminatedEvent } from '../../common/notification';
 import { PERIPHERAL_ID_SEP, PeripheralBaseNodeDTO } from '../../common/peripheral-dto';
 import * as manifest from '../../manifest';
-import { PeripheralBaseNode } from '../../model/peripheral/nodes';
+import { PeripheralBaseNode, PeripheralRegisterNode } from '../../model/peripheral/nodes';
 import { PeripheralDataTracker } from '../../model/peripheral/tree/peripheral-data-tracker';
 
 export class PeripheralTreeDataProvider implements CDTTreeDataProvider<PeripheralBaseNode, PeripheralBaseNodeDTO> {
@@ -21,6 +21,10 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
     readonly onDidTerminate = this.onDidTerminateEvent.event;
     protected onDidChangeTreeDataEvent = new vscode.EventEmitter<TreeNotification<PeripheralBaseNode | PeripheralBaseNode[] | undefined>>();
     readonly onDidChangeTreeData = this.onDidChangeTreeDataEvent.event;
+
+    private includeIds?: Set<string>;
+    private defaultExpandedIds?: Set<string>;
+    private searchSequence = 0;
 
     constructor(protected readonly dataTracker: PeripheralDataTracker, protected context: vscode.ExtensionContext) {
         this.dataTracker.onDidTerminate((event) => {
@@ -56,6 +60,10 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
             webview.onDidToggleNode((event) => {
                 const node = this.getNodeByItemId(event.data);
                 this.dataTracker.toggleNode(node, true);
+            }),
+            webview.onDidSearchChanged((event) => {
+                const text = event.data?.text ?? '';
+                this.handleSearchText(text);
             })
         );
     }
@@ -76,9 +84,71 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
     async getSerializedData(element: PeripheralBaseNode): Promise<PeripheralBaseNodeDTO> {
         const item = await element.serialize();
 
-        const children = await this.getChildren(element);
-        if (children && children?.length > 0) {
-            item.children = await Promise.all(children.map(c => this.getSerializedData(c)));
+        // ===== SEARCH MODE =====
+        if (this.includeIds) {
+            const includeIds = this.includeIds;
+
+            if (!includeIds.has(element.getId())) {
+                return item;
+            }
+
+            const children = (await this.getChildren(element)) ?? [];
+
+            if (element instanceof PeripheralRegisterNode) {
+                item.expanded =
+                    element.expanded ||
+                    this.defaultExpandedIds?.has(element.getId()) === true;
+
+                if (children.length > 0) {
+                    item.children = await Promise.all(
+                        children.map(child => this.getSerializedData(child))
+                    );
+                }
+
+                return item;
+            }
+
+            const visibleChildren = children.filter(child =>
+                includeIds.has(child.getId())
+            );
+
+            if (visibleChildren.length > 0) {
+                item.expanded =
+                    element.expanded ||
+                    this.defaultExpandedIds?.has(element.getId()) === true;
+
+                item.children = await Promise.all(
+                    visibleChildren.map(child => this.getSerializedData(child))
+                );
+            }
+
+            return item;
+        }
+
+        // ===== NORMAL LAZY MODE =====
+
+        if (element instanceof PeripheralRegisterNode) {
+            const children = (await this.getChildren(element)) ?? [];
+
+            if (children.length > 0) {
+                item.children = await Promise.all(
+                    children.map(child => this.getSerializedData(child))
+                );
+            }
+
+            return item;
+        }
+
+        if (!element.expanded) {
+            return item;
+        }
+
+        const children = (await this.getChildren(element)) ?? [];
+
+        if (children.length > 0) {
+            item.children = await Promise.all(
+                children.map(child => this.getSerializedData(child))
+            );
         }
 
         return item;
@@ -99,6 +169,46 @@ export class PeripheralTreeDataProvider implements CDTTreeDataProvider<Periphera
         }
 
         return node;
+    }
+
+    private handleSearchText(text: string): void {
+        const sequence = ++this.searchSequence;
+        const normalized = (text ?? '').trim();
+
+        if (!normalized) {
+            this.searchSequence++;
+            this.includeIds = undefined;
+            this.defaultExpandedIds = undefined;
+            this.onDidChangeTreeDataEvent.fire({ data: undefined });
+            return;
+        }
+
+        void (async () => {
+            const matches = await this.dataTracker.findNodesByText(normalized);
+
+            if (sequence !== this.searchSequence) {
+                return; // Ignore stale results
+            }
+
+            const include = new Set<string>();
+            const expand = new Set<string>();
+
+            for (const node of matches) {
+                include.add(node.getId());
+
+                let parent = node.getParent?.() as PeripheralBaseNode | undefined;
+                while (parent) {
+                    include.add(parent.getId());
+                    expand.add(parent.getId());
+                    parent = parent.getParent?.() as PeripheralBaseNode | undefined;
+                }
+            }
+
+            this.includeIds = include;
+            this.defaultExpandedIds = expand;
+
+            this.onDidChangeTreeDataEvent.fire({ data: undefined });
+        })();
     }
 
 }

--- a/src/views/peripheral/peripheral-view.tsx
+++ b/src/views/peripheral/peripheral-view.tsx
@@ -192,6 +192,7 @@ export class CDTTreeView extends React.Component<unknown, State> {
             <CDTTree<PeripheralTreeNodeDTOs>
                 dataSource={this.state.viewModel.items}
                 dataSourceSorter={(dataSource) => this.dataSourceSorter(dataSource)}
+                search={{ mode: 'backend' }}
                 columnDefinitions={this.state.extensionModel.columnFields}
                 expansion={{
                     expandedRowKeys: this.state.viewModel.expandedKeys,

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,18 +224,18 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-1.0.0.tgz#f75c08f88cfd9eb8d9b062284d5bbcc60c41bf2a"
   integrity sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==
 
-"@eclipse-cdt-cloud/vscode-ui-components@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@eclipse-cdt-cloud/vscode-ui-components/-/vscode-ui-components-0.0.1.tgz#40b5026f6c3649263ed2e144fcc42e6f0d4342d8"
-  integrity sha512-2gNkyedlQeRvsAK5PGsXLqI7uhgxaDCx8A3ObpLEfwxwGwgsH89ETGEZBKY6pdMWvK9lGhfNlJx0EFLrr4Eheg==
+"@eclipse-cdt-cloud/vscode-ui-components@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@eclipse-cdt-cloud/vscode-ui-components/-/vscode-ui-components-0.1.0.tgz#f76563bd9ea1b9b1bce120dfb045dd9036e71dc3"
+  integrity sha512-HzTDOO2Q+TfeJDYTrUhpjiDSI6LfSCRTttLlG7o7dMaQ/P3zDUtlUFQt9ILUts8X7c8Jb3jZo+DLZ32uXyLWew==
   dependencies:
-    "@floating-ui/react" "^0.26.17"
-    "@vscode/codicons" "0.0.20"
+    "@floating-ui/react" "^0.27.19"
+    "@vscode/codicons" "0.0.44"
     "@vscode/webview-ui-toolkit" "^1.4.0"
     antd "^5.22.1"
     re-resizable "^6.11.2"
-    react-markdown "^9.0.1"
-    remark-gfm "^4.0.0"
+    react-markdown "^10.1.0"
+    remark-gfm "^4.0.1"
     throttle-debounce "5.0.2"
     vscode-messenger "^0.4.5"
     vscode-messenger-common "^0.4.5"
@@ -304,41 +304,41 @@
     "@eslint/core" "^1.1.1"
     levn "^0.4.1"
 
-"@floating-ui/core@^1.0.0":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.2.tgz#d37f3e0ac1f1c756c7de45db13303a266226851a"
-  integrity sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==
+"@floating-ui/core@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.5.tgz#d4af157a03330af5a60e69da7a4692507ada0622"
+  integrity sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==
   dependencies:
-    "@floating-ui/utils" "^0.2.0"
+    "@floating-ui/utils" "^0.2.11"
 
-"@floating-ui/dom@^1.0.0":
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.5.tgz#323f065c003f1d3ecf0ff16d2c2c4d38979f4cb9"
-  integrity sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==
+"@floating-ui/dom@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.6.tgz#f915bba5abbb177e1f227cacee1b4d0634b187bf"
+  integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
   dependencies:
-    "@floating-ui/core" "^1.0.0"
-    "@floating-ui/utils" "^0.2.0"
+    "@floating-ui/core" "^1.7.5"
+    "@floating-ui/utils" "^0.2.11"
 
-"@floating-ui/react-dom@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.0.tgz#4f0e5e9920137874b2405f7d6c862873baf4beff"
-  integrity sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==
+"@floating-ui/react-dom@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.8.tgz#5fb5a20d10aafb9505f38c24f38d00c8e1598893"
+  integrity sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==
   dependencies:
-    "@floating-ui/dom" "^1.0.0"
+    "@floating-ui/dom" "^1.7.6"
 
-"@floating-ui/react@^0.26.17":
-  version "0.26.17"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.17.tgz#efa2e1a0dea3d9d308965c5ccd49756bb64a883d"
-  integrity sha512-ESD+jYWwqwVzaIgIhExrArdsCL1rOAzryG/Sjlu8yaD3Mtqi3uVyhbE2V7jD58Mo52qbzKz2eUY/Xgh5I86FCQ==
+"@floating-ui/react@^0.27.19":
+  version "0.27.19"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.19.tgz#d8d5d895b7cb97dac370bfbf55f3e630878fdf1f"
+  integrity sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==
   dependencies:
-    "@floating-ui/react-dom" "^2.1.0"
-    "@floating-ui/utils" "^0.2.0"
+    "@floating-ui/react-dom" "^2.1.8"
+    "@floating-ui/utils" "^0.2.11"
     tabbable "^6.0.0"
 
-"@floating-ui/utils@^0.2.0":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.2.tgz#d8bae93ac8b815b2bd7a98078cf91e2724ef11e5"
-  integrity sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==
+"@floating-ui/utils@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
+  integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -985,10 +985,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vscode/codicons@0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.20.tgz#8f52b8caf3b89fbb66bb3cd856c723e7696d5a46"
-  integrity sha512-LlO6K7nzrIWDCZN1Zi6J6ibxrpMibSAct+zNjAwpkNkwup6cJLx5diYvsOJODMPWOuQlBO21qkxtdkSRzW6+Jw==
+"@vscode/codicons@0.0.44":
+  version "0.0.44"
+  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.44.tgz#c1b6bebc5ae318314894df0e4dc154bd26946c6c"
+  integrity sha512-F7qPRumUK3EHjNdopfICLGRf3iNPoZQt+McTHAn4AlOWPB3W2kL4H0S7uqEqbyZ6rCxaeDjpAn3MCUnwTu/VJQ==
 
 "@vscode/codicons@0.0.45":
   version "0.0.45"
@@ -4598,12 +4598,13 @@ react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-react-markdown@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-9.0.1.tgz#c05ddbff67fd3b3f839f8c648e6fb35d022397d1"
-  integrity sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==
+react-markdown@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-10.1.0.tgz#e22bc20faddbc07605c15284255653c0f3bad5ca"
+  integrity sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==
   dependencies:
     "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
     devlop "^1.0.0"
     hast-util-to-jsx-runtime "^2.0.0"
     html-url-attributes "^3.0.0"
@@ -4688,10 +4689,10 @@ registry-url@3.1.0:
   dependencies:
     rc "^1.0.1"
 
-remark-gfm@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-4.0.0.tgz#aea777f0744701aa288b67d28c43565c7e8c35de"
-  integrity sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==
+remark-gfm@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-4.0.1.tgz#33227b2a74397670d357bf05c098eaf8513f0d6b"
+  integrity sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==
   dependencies:
     "@types/mdast" "^4.0.0"
     mdast-util-gfm "^3.0.0"


### PR DESCRIPTION
Fixes #71
 
Handle peripheral tree search in the extension backend.
 
The backend computes matching nodes and returns only the minimal
matching subtree. Children are serialized lazily to reduce webview
load and improve performance for large SVD files.