### PR TITLE
Update transient dependencies

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,9 +1513,9 @@ boxen@7.0.0:
     wrap-ansi "^8.0.1"
 
 brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
+  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
Patches lockfile to the following dependencies. This should fix the majority of open dependabot alerts:
- ajv 8.18.0
- brace-expansion 1.1.12
- cross-spawn 7.0.6
- glob 11.1.0
- jws 3.2.3
- jws 4.0.1
- minimatch 3.1.5
- minimatch 10.2.4
- semver 5.7.2
- semver 7.7.4

Other changes are newly resolved dependencies of those dependencies.