### PR TITLE
v1.9.0 Release Preparations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [v1.9.0] - 2026-03-25
+
+### New Features
+
+- Extension API allows to get interrupt tables from SVD files. ([#76](https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/76), [Jens Reinecke](https://github.com/jreineckearm))
+
+### Bug Fixes
+
+- VS Code freezes/crashes when loading a large register set (~500K lines). ([#71](https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/71), [phongtrinh1234](https://github.com/phongtrinh1234))
+- `dimIndex` range starting with zero expands to `UNDEFINED`. ([#72](https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/72), [Thorsten de Buhr](https://github.com/thorstendb-ARM/))
+
+### Other Changes
+
+- chore: Dependency updates
+
 ## [v1.8.1] - 2025-07-09
 
 ### Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,24 +48,14 @@ electronically sign the Eclipse Contributor Agreement (ECA).
 
 * http://www.eclipse.org/legal/ECA.php
 
-Commits that are provided by non-committers must have a Signed-off-by field in
-the footer indicating that the author is aware of the terms by which the
-contribution has been provided to the project. The non-committer must
-additionally have an Eclipse Foundation account and must have a signed Eclipse
+Non-committers must have an Eclipse Foundation account and must have a signed Eclipse
 Contributor Agreement (ECA) on file.
 
 For more information, please see the Eclipse Committer Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit
 
-## Sign your work
+## Contact
 
-The sign-off is a simple line at the end of the explanation for the patch. Your
-signature certifies that you wrote the patch or otherwise have the right to
-pass it on as an open-source patch.
+Contact the project developers via the project's "dev" list.
 
-    Signed-off-by: Joe Smith <joe.smith@email.com>
-
-Use your real name (sorry, no pseudonyms or anonymous contributions.)
-
-If you set your `user.name` and `user.email` git configs, you can sign your
-commit automatically with `git commit -s`.
+- https://dev.eclipse.org/mailman/listinfo/cdt-cloud-dev

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright 2024-2026 EclipseSource, Arm Limited, and others
 Copyright 2017-2023 Marcel Ball and Arm Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peripheral-inspector",
   "displayName": "Peripheral Inspector",
   "description": "Standalone Peripheral Inspector extension extracted from cortex-debug",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "publisher": "eclipse-cdt",
   "author": "marus25",
   "contributors": [


### PR DESCRIPTION
- Bump version and update changelog.
- Updates LICENSE text to cover copyright for changes since 2024.
- Updates CONTRIBUTING.md to remove the sign-off requirement.

@planger , I retrospectively updated the copyright owners for changes since 2024 including EclipseSource's name. Do you approve?
@phongtrinh1234 , since you made a major contribution with recent fixes, would you like me to call out your company name in the LICENSE file, too?