### PR TITLE
Duplicate field names cause incorrect field rendering

### DIFF
--- a/src/model/peripheral/nodes/peripheral-field-node.ts
+++ b/src/model/peripheral/nodes/peripheral-field-node.ts
@@ -10,7 +10,7 @@ import { AddrRange, BitRange } from '../../../addrranges';
 import { AccessType, EnumerationMap, FieldOptions, ReadActionType } from '../../../api-types';
 import { NodeSetting } from '../../../common';
 import { NumberFormat } from '../../../common/format';
-import { PeripheralFieldNodeDTO } from '../../../common/peripheral-dto';
+import { PERIPHERAL_ID_SEP, PeripheralFieldNodeDTO } from '../../../common/peripheral-dto';
 import { parseInteger } from '../../../utils';
 import { PeripheralBaseNode, UpdateDataContext } from './base-node';
 import { PeripheralRegisterNode } from './peripheral-register-node';
@@ -31,6 +31,12 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
     private previousValue?: number;
     private currentValue?: number;
 
+    /**
+     * Unique ID segment for this field, combining name with bit position to
+     * disambiguate fields that share the same name within a register.
+     */
+    public readonly idSegment: string;
+
     constructor(public parent: PeripheralRegisterNode, protected options: FieldOptions) {
         super(parent);
 
@@ -38,6 +44,7 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
         this.description = options.description;
         this.offset = options.offset;
         this.width = options.width;
+        this.idSegment = `${this.name}[${this.offset}:${this.width}]`;
         this.readAction = options.readAction;
 
         if (!options.accessType) {
@@ -138,9 +145,13 @@ export class PeripheralFieldNode extends PeripheralBaseNode {
         return true;
     }
 
+    public getId(): string {
+        return `${this.parent.getId()}${PERIPHERAL_ID_SEP}${this.idSegment}`;
+    }
+
     public saveState(path: string): NodeSetting[] {
         if (this.format !== NumberFormat.Auto) {
-            return [{ node: `${path}.${this.name}`, format: this.format }];
+            return [{ node: `${path}.${this.idSegment}`, format: this.format }];
         } else {
             return [];
         }

--- a/src/model/peripheral/nodes/peripheral-register-node.ts
+++ b/src/model/peripheral/nodes/peripheral-register-node.ts
@@ -174,7 +174,8 @@ export class PeripheralRegisterNode extends ClusterOrRegisterBaseNode {
         if (path.length === 0) {
             return this;
         } else if (path.length === 1) {
-            const child = this.children.find((c) => c.name === path[0]);
+            const child = this.children.find((c) => c.idSegment === path[0])
+                ?? this.children.find((c) => c.name === path[0]);
             return child;
         } else {
             return undefined;


### PR DESCRIPTION
## Fix
Fixed issue by generating proper IDs for multiple defined fields (which should not occur!).

## Ref
https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/73