### PR TITLE
publishing extension API to NPM github registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-        registry-url: https://npm.pkg.github.com/
-           scope: '@eclipse-cdt-cloud'
-           always-auth: true
+          registry-url: https://npm.pkg.github.com/
+          scope: '@eclipse-cdt-cloud'
+          always-auth: true
       - name: Build
         env:
-          - GITHUB_TOKEN: ${{github.token}}
-          - NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{github.token}}
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           yarn install --ignore-scripts
           yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{github.token}}
         run: |
-          cp src/api-types.ts api/peripheral-inspector.d.ts
           yarn install --ignore-scripts
           yarn build
           yarn package
@@ -93,7 +92,12 @@ jobs:
         run: yarn --cwd api version --no-git-tag-version --new-version=$VERSION
         env:
           VERSION: ${{ needs.determine-version.outputs.version }}
-      - run: yarn publish
+      - name: Build API Types
+        run: |
+          yarn install --ignore-scripts
+          yarn build:api
+      - name: Publish API Types
+        run: yarn publish
         working-directory: api
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
            always-auth: true
       - name: Build
         env:
-          GITHUB_TOKEN: ${{github.token}}
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          - GITHUB_TOKEN: ${{github.token}}
+          - NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           yarn install --ignore-scripts
           yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,46 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*/*.vsix
+  determine-version:
+    name: Determine Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-extension-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Determine Extension Version
+        id: get-extension-version
+        run: |
+          VERSION=$(npm pkg get version | sed 's/"//g')
+          echo "Current version: $VERSION"
+          echo version=$VERSION >> $GITHUB_OUTPUT
+
+  publish-api-types:
+    name: Publish Extension API
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - determine-version
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          registry-url: 'https://npm.pkg.github.com'
+          always-auth: true
+      - name: Set package version to match extension
+        run: yarn --cwd api version --no-git-tag-version --new-version=$VERSION
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+      - run: yarn publish
+        working-directory: api
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-open-vsx-registry:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          registry-url: https://npm.pkg.github.com/
           scope: '@eclipse-cdt-cloud'
           always-auth: true
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
+      - name: Setup .npmrc
+        run: |
+          echo "@eclipse-cdt-cloud:registry=https://npm.pkg.github.com/" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}" >> .npmrc
       - name: Build
         env:
           GITHUB_TOKEN: ${{github.token}}
         run: |
+          cp src/api-types.ts api/peripheral-inspector.d.ts
           yarn install --ignore-scripts
           yarn build
           yarn package
@@ -50,6 +55,7 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*/*.vsix
+  
   determine-version:
     name: Determine Version
     runs-on: ubuntu-latest
@@ -75,11 +81,12 @@ jobs:
       packages: write
     needs:
       - determine-version
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: 'https://npm.pkg.github.com'
           always-auth: true
       - name: Set package version to match extension
@@ -92,7 +99,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-open-vsx-registry:
-    needs: build
+    needs: 
+      - build
+      - publish-api-types
     name: Open VSX
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
@@ -109,7 +118,9 @@ jobs:
           npx ovsx publish -i artifacts/*/*.vsix -p ${{secrets.OPEN_VSX_TOKEN}}
 
   publish-vscode-marketplace:
-    needs: build
+    needs: 
+      - build
+      - publish-api-types
     name: VS Code Marketplace
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          scope: '@eclipse-cdt-cloud'
-          always-auth: true
       - name: Build
         env:
           GITHUB_TOKEN: ${{github.token}}
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           yarn install --ignore-scripts
           yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-      - name: Setup .npmrc
-        run: |
-          echo "@eclipse-cdt-cloud:registry=https://npm.pkg.github.com/" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}" >> .npmrc
+        registry-url: https://npm.pkg.github.com/
+           scope: '@eclipse-cdt-cloud'
+           always-auth: true
       - name: Build
         env:
           GITHUB_TOKEN: ${{github.token}}
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           yarn install --ignore-scripts
           yarn build

--- a/api/package.json
+++ b/api/package.json
@@ -2,7 +2,7 @@
     "name": "@eclipse-cdt-cloud/vscode-peripheral-inspector",
     "version": "0.0.0",
     "description": "API for the eclipse-cdt.peripheral-inspector VS Code extension",
-    "types": "peripheral-inspector.d.ts",
+    "types": "api-types.d.ts",
     "publishConfig": {
         "registry": "https://npm.pkg.github.com"
     },

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "@eclipse-cdt-cloud/vscode-peripheral-inspector",
+    "version": "0.0.0",
+    "description": "API for the eclipse-cdt.peripheral-inspector VS Code extension",
+    "types": "peripheral-inspector.d.ts",
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
+    },
+    "repository": "https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector",
+    "dependencies": {}
+}

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@eclipse-cdt-cloud/vscode-peripheral-inspector",
+    "publisher": "eclipse-cdt",
+    "author": "Eclipse CDT",
+    "license": "MIT",
     "version": "0.0.0",
     "description": "API for the eclipse-cdt.peripheral-inspector VS Code extension",
     "types": "api-types.d.ts",
@@ -7,5 +10,6 @@
         "registry": "https://npm.pkg.github.com"
     },
     "repository": "https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector",
+    "bugs": "https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues",
     "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "watch": "webpack -w",
     "lint": "eslint . --ext .ts,.tsx",
     "package": "vsce package --yarn",
-    "serve": "serve --cors -p 9000"
+    "serve": "serve --cors -p 9000",
+    "build:api": "tsc -p tsconfig.api.json"
   },
   "dependencies": {
     "@eclipse-cdt-cloud/vscode-ui-components": "^0.1.0",
@@ -438,6 +439,5 @@
   "extensionKind": [
     "workspace",
     "ui"
-  ],
-  "build:api": "tsc -p tsconfig.api.json"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -438,5 +438,6 @@
   "extensionKind": [
     "workspace",
     "ui"
-  ]
+  ],
+  "build:api": "tsc -p tsconfig.api.json"
 }

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "declarationMap": false,
+        "outDir": "api",
+        "rootDir": "src",
+        "stripInternal": true
+    },
+    "include": [
+        "src/api-types.ts"
+    ]
+}


### PR DESCRIPTION
Publishing extension's API as an NPM package to improve CI performance for any repo depending on peripheral inspector

Should fix: https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/issues/95