### PR TITLE
v1.9.2 Release Preparations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.9.2] - 2026-06-24
+
+- Fixes publish of Extension API to GitHub NPM registry.  
+- **IMPORTANT**: Extension v1.9.1 did not get published.  
+  See previous release section for features first published with this v1.9.2 release.
+
 ## [v1.9.1] - 2026-06-24
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peripheral-inspector",
   "displayName": "Peripheral Inspector",
   "description": "Standalone Peripheral Inspector extension extracted from cortex-debug",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "publisher": "eclipse-cdt",
   "author": "marus25",
   "contributors": [


### PR DESCRIPTION
- Bump to v1.9.2
- Update changelog

Note: v1.9.1 was not published to the marketplaces. v1.9.2 repeats with hopefully fixed CI.