### PR TITLE
Fix failing version patch for API package publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,32 @@ jobs:
           echo "Current version: $VERSION"
           echo version=$VERSION >> $GITHUB_OUTPUT
 
-  build-api-types:
+  build-api-types-proxy:
     name: Test Build Extension API
     runs-on: ubuntu-latest
     needs:
       - determine-version
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Set package version to match extension
+        run: |
+          echo "Patch version: $VERSION"
+          yarn --cwd api version --no-git-tag-version --new-version=$VERSION
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+      - name: Build API Types
+        run: |
+          yarn install --ignore-scripts
+          yarn build:api
+
+  build-api-types:
+    name: Test Build Extension API
+    runs-on: ubuntu-latest
+    needs:
+      - build-api-types-proxy
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
     name: Test Build Extension API
     runs-on: ubuntu-latest
     needs:
+      - determine-version
       - build-api-types-proxy
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build:
     name: Build
+    needs:
+      - build-api-types
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,13 +65,20 @@ jobs:
         with:
           node-version: 22.x
       - name: Set package version to match extension
-        run: yarn --cwd api version --no-git-tag-version --new-version=$VERSION
+        run: |
+          echo "Patch version: $VERSION"
+          yarn --cwd api version --no-git-tag-version --new-version=$VERSION
         env:
           VERSION: ${{ needs.determine-version.outputs.version }}
       - name: Build API Types
         run: |
           yarn install --ignore-scripts
           yarn build:api
+      - uses: actions/upload-artifact@v4
+        with:
+          name: api-types-package
+          path: ./api/*
+          retention-days: 1
 
   release:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ on:
 jobs:
   build:
     name: Build
-    needs:
-      - build-api-types
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,53 +52,24 @@ jobs:
           echo "Current version: $VERSION"
           echo version=$VERSION >> $GITHUB_OUTPUT
 
-  build-api-types-proxy:
-    name: Test Build Extension API
-    runs-on: ubuntu-latest
-    needs:
-      - determine-version
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-      - name: Set package version to match extension
-        run: |
-          echo "Patch version: $VERSION"
-          yarn --cwd api version --no-git-tag-version --new-version=$VERSION
-        env:
-          VERSION: ${{ needs.determine-version.outputs.version }}
-      - name: Build API Types
-        run: |
-          yarn install --ignore-scripts
-          yarn build:api
-
   build-api-types:
     name: Test Build Extension API
     runs-on: ubuntu-latest
     needs:
       - determine-version
-      - build-api-types-proxy
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
       - name: Set package version to match extension
-        run: |
-          echo "Patch version: $VERSION"
-          yarn --cwd api version --no-git-tag-version --new-version=$VERSION
+        run: yarn --cwd api version --no-git-tag-version --new-version=$VERSION
         env:
           VERSION: ${{ needs.determine-version.outputs.version }}
       - name: Build API Types
         run: |
           yarn install --ignore-scripts
           yarn build:api
-      - uses: actions/upload-artifact@v4
-        with:
-          name: api-types-package
-          path: ./api/*
-          retention-days: 1
 
   release:
     needs:
@@ -127,6 +96,7 @@ jobs:
       contents: read
       packages: write
     needs:
+      - determine-version
       - build-api-types
     if: startsWith(github.ref, 'refs/tags/')
     steps:


### PR DESCRIPTION
 - CI tests to find out where determined VERSION for API package went during last publish.
   - https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/pull/123/commits/7b3e10806161ef2114036f4767d7020e271a538e : successful, `determine-version` is direct `needs` dependency of `Test Build Extension API`. See https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/actions/runs/28809919799/job/85434948426#step:4:8
   - https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/pull/123/commits/8d107bc4c169ba81783747bf493ba8eab60adc01 : added `Test Build Extension API` twice, one with the job name extended with -`proxy` (probably not 100% correct terminology). `build-api-types-proxy` `needs` `determine-version` directly, the other `needs` `build-api-types-proxy`, i.e. `determine-version` is not directly needed. This is similar to the chained dependencies on current `main`: `determine-version` -> `build-api-types` -> `publish-api-types`
     - First job with direct `determine-version` need succeeds: https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/actions/runs/28810761093/job/85437794646#step:4:8
     - Second job without direct `determine-version` doesn't get the determined version, very likely because of missing `needs`. https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/actions/runs/28810761093/job/85437945596#step:4:8
     - Caution, the listed `Test Build Extension API` jobs have the same name in the summary and are in reverse order. Use above links or the flow chart to avoid confusion.
    - https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/pull/123/commits/36d0400e3e69f7e49527d2af0e50be94b9a1d9a8 , same as previous but additionally `needs` `determine-version` in the second build api job. Both get the correct patch version.
      - https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/actions/runs/28811326308/job/85439711977#step:4:8
      - https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/actions/runs/28811326308/job/85439842409#step:4:8

So, the problem is that `publish-api-types` requires a direct `needs` reference to `determine-version` to fetch the correct output version variable. And I broke the `needs` chain while introducing the test API build job before the last release here: https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/pull/120/changes#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR99

Above trials are removed in last commit https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/pull/123/commits/0fd2de8e9e22ea8cec74f57cc71112326e50c43a which applies the actual fix. To be squashed before merge.
Ultimate test things are working can only happen during next real publish.