### PR TITLE
Add API to re-initialize peripheral view with deferred SVD path

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -5,6 +5,8 @@
  * terms of the MIT License as outlined in the LICENSE File
  *********************************************************************/
 
+import type { DebugSession } from 'vscode';
+
 // Peripheral Inspector API
 export interface IPeripheralInspectorAPI {
     registerSVDFile: (expression: RegExp | string, path: string) => void;
@@ -19,6 +21,15 @@ export interface IPeripheralInspectorAPI {
      * @returns The interrupt table for the SVD file, or undefined if the file was not loaded.
      */
     getInterruptTable?: (svdPath: string) => InterruptTable | undefined;
+    /**
+     * (re)initialize the Peripheral view for an active debug session.
+     * Use to defer loading of large SVD definition files until after
+     * the debug session is ready, or when definitionPath was empty at session start.
+     *
+     * @param session The active VS Code debug session.
+     * @param svdPath Absolute path to the SVD definition file.
+     */
+    loadPeripheralsForSession?: (session: DebugSession, svdPath: string) => Promise<void>;
 }
 
 export interface IPeripheralsProvider {

--- a/src/entry-points/browser/extension.ts
+++ b/src/entry-points/browser/extension.ts
@@ -24,6 +24,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<IPerip
     const resolver = new SvdResolver(api, config);
 
     const peripheralDataTracker = new PeripheralDataTracker(tracker, resolver, api, config, context);
+    api.setSessionLoader(peripheralDataTracker);
     const dataProvider = new PeripheralTreeDataProvider(peripheralDataTracker, context);
     const webView = new PeripheralsTreeTableWebView(dataProvider, context);
     const commands = new PeripheralCommands(peripheralDataTracker, config, webView);

--- a/src/entry-points/desktop/extension.ts
+++ b/src/entry-points/desktop/extension.ts
@@ -26,6 +26,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<IPerip
     const resolver = new SvdResolver(api, config);
 
     const peripheralDataTracker = new PeripheralDataTracker(tracker, resolver, api, config, context);
+    api.setSessionLoader(peripheralDataTracker);
     const dataProvider = new PeripheralTreeDataProvider(peripheralDataTracker, context);
     const webView = new PeripheralsTreeTableWebView(dataProvider, context);
     const commands = new PeripheralCommands(peripheralDataTracker, config, webView);

--- a/src/model/peripheral/tree/peripheral-data-tracker.ts
+++ b/src/model/peripheral/tree/peripheral-data-tracker.ts
@@ -298,6 +298,22 @@ export class PeripheralDataTracker {
         this.onDidChangeEvent.fire(changes);
     }
 
+    /**
+     * Lazily (re)initialize peripherals for a session with an explicit SVD definition path.
+     * Replaces any existing tree for the session so deferred callers are idempotent.
+     */
+    public async loadPeripheralsForSession(session: vscode.DebugSession, svdPath: string): Promise<void> {
+        if (!svdPath?.trim()) {
+            throw new Error('Peripheral definition path is required');
+        }
+
+        if (this.sessionPeripherals.get(session.id)) {
+            this.onDebugSessionTerminated(session);
+        }
+
+        await this.createSessionPeripherals(session, svdPath);
+    }
+
     protected async onDebugSessionStarted(session: vscode.DebugSession): Promise<void> {
         const wsFolderPath = session.workspaceFolder ? session.workspaceFolder.uri : vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0].uri;
         const svdPath = await this.resolver.resolve(session, wsFolderPath);
@@ -312,6 +328,11 @@ export class PeripheralDataTracker {
             return;
         }
 
+        await this.createSessionPeripherals(session, svdPath);
+    }
+
+    /** @param svdPath Absolute path to the SVD definition file. */
+    protected async createSessionPeripherals(session: vscode.DebugSession, svdPath: string): Promise<void> {
         let expanded = this.oldState.get(session.name);
         if (expanded === undefined) {
             expanded = this.sessionPeripherals.size === 0 ? true : false;

--- a/src/peripheral-inspector-api.ts
+++ b/src/peripheral-inspector-api.ts
@@ -24,12 +24,18 @@ interface LoadedSVDInfo {
     interruptTable?: InterruptTable;
 }
 
+export interface IPeripheralSessionLoader {
+    /**
+     * @param svdPath Absolute path to the SVD definition file.
+     */
+    loadPeripheralsForSession(session: vscode.DebugSession, svdPath: string): Promise<void>;
+}
+
 export class PeripheralInspectorAPI implements IPeripheralInspectorAPI {
     private SVDDirectory: SVDInfo[] = [];
     private PeripheralProviders: Record<string, IPeripheralsProvider> = {};
     private LoadedSVDInfos: Record<string, LoadedSVDInfo> = {};
-
-    /** IPeripheralInspectorAPI implementation */
+    private sessionLoader?: IPeripheralSessionLoader;
 
     public registerSVDFile(expression: RegExp | string, path: string): void {
         if (typeof expression === 'string') {
@@ -76,6 +82,24 @@ export class PeripheralInspectorAPI implements IPeripheralInspectorAPI {
     }
 
     /** Locally used methods */
+
+    /** IPeripheralInspectorAPI implementation */
+    public setSessionLoader(loader: IPeripheralSessionLoader): void {
+        this.sessionLoader = loader;
+    }
+
+    /**
+     * @param svdPath Absolute path to the SVD definition file.
+     */
+    public async loadPeripheralsForSession(
+        session: vscode.DebugSession,
+        svdPath: string,
+    ): Promise<void> {
+        if (!this.sessionLoader) {
+            throw new Error('Peripheral Inspector session loader is not initialized');
+        }
+        return this.sessionLoader.loadPeripheralsForSession(session, svdPath);
+    }
 
     public getPeripheralsProvider(svdPath: string): IPeripheralsProvider | undefined {
         const ext = Object.keys(this.PeripheralProviders).filter((extension) => svdPath.endsWith(`.${extension}`))[0];


### PR DESCRIPTION
Add loadPeripheralsForSession API to defer peripheral initialization

Large SVD files can slow down debug session startup while the core waits for port attachment. This API allows deferring peripheral tree initialization and retriggering it once the debug session is ready.

## Summary

* Add `loadPeripheralsForSession(session, svdPath)` to support deferred and on-demand initialization of the Peripheral view.
* Refactor `PeripheralDataTracker` by extracting session initialization into a reusable `createSessionPeripherals()` method.
* Integrate the new session loading API into both the browser and desktop extension entry points.

## Motivation

Initializing the Peripheral view for large SVD files can significantly increase debug session startup time, as the debug adapter must wait for peripheral initialization to complete before continuing. This results in a slower and less responsive debugging experience.

This change introduces a new API that allows external extensions (such as Cortex-Debug) to defer peripheral initialization until the debug session is fully established. The Peripheral view can then be initialized on demand by calling `loadPeripheralsForSession(session, svdPath)`.

## Test Plan

- Verify that a debug session using a large SVD file starts without being blocked by Peripheral view initialization.
- Verify that calling `loadPeripheralsForSession(session, svdPath)` after the debug session is attached correctly loads the Peripheral view.
- Verify that calling `loadPeripheralsForSession(session, svdPath)` multiple times for the same session safely replaces the existing peripheral tree without creating duplicates.
- Verify that the existing behavior for small SVD files (immediate initialization) remains unchanged.
